### PR TITLE
Proposed test: b903, data classes should be namedtuples or slots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,12 @@ instance methods, and `cls` for class methods (which includes `__new__`
 and `__init_subclass__`) or instance methods of metaclasses (detected as
 classes directly inheriting from ``type``).
 
+**B903**: Use ``collections.namedtuple`` (or ``typing.NamedTuple``) for
+data classes that only set attributes in an ``__init__`` method, and do
+nothing else. If the attributes should be immutable, define the attributes
+in ``__slots__`` to save per-instance memory and to prevent accidentally 
+creating additional attributes on instances.
+
 **B950**: Line too long. This is a pragmatic equivalent of ``pycodestyle``'s
 E501: it considers "max-line-length" but only triggers when the value has been
 exceeded by **more than 10%**. You will no longer be forced to reformat code
@@ -188,6 +194,8 @@ MIT
 
 Change Log
 ----------
+
+* introduced B903 (patch contributed by Martijn Pieters)
 
 17.2.1
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ classes directly inheriting from ``type``).
 
 **B903**: Use ``collections.namedtuple`` (or ``typing.NamedTuple``) for
 data classes that only set attributes in an ``__init__`` method, and do
-nothing else. If the attributes should be immutable, define the attributes
+nothing else. If the attributes should be mutable, define the attributes
 in ``__slots__`` to save per-instance memory and to prevent accidentally 
 creating additional attributes on instances.
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -380,14 +380,21 @@ class BugBearVisitor(ast.NodeVisitor):
             )
 
     def check_for_b903(self, node):
-        if (len(node.body) != 1 or
-                not isinstance(node.body[0], ast.FunctionDef) or
-                node.body[0].name != '__init__'):
+        body = node.body[:]
+        if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Str):
+            # Ignore the docstring
+            body = body[1:]
+
+        if (
+            len(body) != 1 or
+            not isinstance(body[0], ast.FunctionDef) or
+            body[0].name != '__init__'
+        ):
             # only classes with *just* an __init__ method are interesting
             return
 
         # all the __init__ function does is a series of assignments to attributes
-        for stmt in node.body[0].body:
+        for stmt in body[0].body:
             if not isinstance(stmt, ast.Assign):
                 return
             targets = stmt.targets

--- a/bugbear.py
+++ b/bugbear.py
@@ -380,7 +380,7 @@ class BugBearVisitor(ast.NodeVisitor):
             )
 
     def check_for_b903(self, node):
-        body = node.body[:]
+        body = node.body
         if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Str):
             # Ignore the docstring
             body = body[1:]

--- a/bugbear.py
+++ b/bugbear.py
@@ -226,6 +226,10 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b006(node)
         self.generic_visit(node)
 
+    def visit_ClassDef(self, node):
+        self.check_for_b903(node)
+        self.generic_visit(node)
+
     def compose_call_path(self, node):
         if isinstance(node, ast.Attribute):
             yield from self.compose_call_path(node.value)
@@ -375,6 +379,26 @@ class BugBearVisitor(ast.NodeVisitor):
                 )
             )
 
+    def check_for_b903(self, node):
+        if (len(node.body) != 1 or
+                not isinstance(node.body[0], ast.FunctionDef) or
+                node.body[0].name != '__init__'):
+            # only classes with *just* an __init__ method are interesting
+            return
+
+        # all the __init__ function does is a series of assignments to attributes
+        for stmt in node.body[0].body:
+            if not isinstance(stmt, ast.Assign):
+                return
+            targets = stmt.targets
+            if len(targets) > 1 or not isinstance(targets[0], ast.Attribute):
+                return
+            if not isinstance(stmt.value, ast.Name):
+                return
+
+        self.errors.append(
+            B903(node.lineno, node.col_offset))
+
 
 @attr.s
 class NameFinder(ast.NodeVisitor):
@@ -522,8 +546,14 @@ B902.self = ['self']  # it's a list because the first is preferred
 B902.cls = ['cls', 'klass']  # ditto.
 B902.metacls = ['metacls', 'metaclass', 'typ']  # ditto.
 
+B903 = Error(
+    message="B903 Data class should either be immutable or use __slots__ to "
+            "save memory. Use collections.namedtuple to generate an immutable "
+            "class, or enumerate the attributes in a __slot__ declaration in "
+            "the class to leave attributes mutable.")
+
 B950 = Error(
     message='B950 line too long ({} > {} characters)',
 )
 
-disabled_by_default = ["B901", "B902", "B950"]
+disabled_by_default = ["B901", "B902", "B903", "B950"]

--- a/tests/b903.py
+++ b/tests/b903.py
@@ -33,3 +33,10 @@ class Warnings:
     def __init__(self, foo, bar):
         self.foo = foo
         self.bar = bar
+
+
+class WarningsWithDocstring:
+    """A docstring should not be an impediment to a warning"""
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar

--- a/tests/b903.py
+++ b/tests/b903.py
@@ -1,0 +1,35 @@
+class NoWarningsMoreMethods:
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar
+
+    def other_function(self):
+        ...
+
+
+class NoWarningsClassAttributes:
+    spam = 'ham'
+
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar
+
+
+class NoWarningsComplicatedAssignment:
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar
+        self.spam = ' - '.join([foo, bar])
+
+
+class NoWarningsMoreStatements:
+    def __init__(self, foo, bar):
+        foo = ' - '.join([foo, bar])
+        self.foo = foo
+        self.bar = bar
+
+
+class Warnings:
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -19,6 +19,7 @@ from bugbear import (
     B306,
     B901,
     B902,
+    B903,
     B950,
 )
 
@@ -149,6 +150,15 @@ class BugbearTestCase(unittest.TestCase):
                 B902(62, 17, vars=("'self'", 'metaclass instance', 'cls')),
                 B902(66, 20, vars=("'cls'", 'metaclass class', 'metacls')),
             )
+        )
+
+    def test_b903(self):
+        filename = Path(__file__).absolute().parent / 'b903.py'
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(B903(32, 0)),
         )
 
     def test_b950(self):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -158,7 +158,7 @@ class BugbearTestCase(unittest.TestCase):
         errors = list(bbc.run())
         self.assertEqual(
             errors,
-            self.errors(B903(32, 0)),
+            self.errors(B903(32, 0), B903(38, 0)),
         )
 
     def test_b950(self):


### PR DESCRIPTION
This tests for

```python
class Foo:
    def __init__(self, bar, spam, eggs):
        self.bar = bar
        self.spam = spam
        self.eggs = eggs
```

resulting in

> B903 Data class should either be immutable or use \_\_slots__ to save memory. Use collections.namedtuple to generate an immutable class, or enumerate the attributes in a \_\_slot__ declaration in the class to leave attributes mutable.
