### PR TITLE
Remove Python 3.6-dev from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
     - 3.5
     - 3.6
-    - 3.6-dev
     - 3.7-dev
 install: pip install -e .
 script: python setup.py test


### PR DESCRIPTION
Python 3.6 is now stable and released. Can test against the released 3.6 instead of 3.6-dev. Testing both is redundant.