### PR TITLE
Fix pathlib link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ that, right?  `six <https://pypi.python.org/pypi/six>`_ or
 
 By making the code exclusively Python 3.5+, I'm able to focus on the
 quality of the checks and re-use all the nice features of the new
-releases (check out `pathlib <docs.python.org/3/library/pathlib.html>`_)
+releases (check out `pathlib <https://docs.python.org/3/library/pathlib.html>`_)
 instead of wasting cycles on Unicode compatibility, etc.
 
 


### PR DESCRIPTION
Previously without the schema, it would have an invalid link, creating a relative link within github.com
Adding the `https://` created the appropriate absolute link.