### PR TITLE
Add trove classifier 'Programming Language :: Python :: 3 :: Only'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Quality Assurance',
     ],


### PR DESCRIPTION
As the project only supports Python 3, should document this using ad trove classifier in setup.py.

For a full list of trove classifiers, see:

https://pypi.python.org/pypi?%3Aaction=list_classifiers