### PR TITLE
Avoid adding the visitor as an __init__ parameter (Fixes #39)

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -24,7 +24,7 @@ class BugBearChecker:
     filename = attr.ib(default='(none)')
     lines = attr.ib(default=None)
     max_line_length = attr.ib(default=79)
-    visitor = attr.ib(default=attr.Factory(lambda: BugBearVisitor))
+    visitor = attr.ib(init=False, default=attr.Factory(lambda: BugBearVisitor))
     options = attr.ib(default=None)
 
     def run(self):


### PR DESCRIPTION
Even with a default value, this produces warnings from flake8's plugin parameter validation. The plugin is never manually instantiating an instance anywhere, so the current ability to pass it in is unused.