### PR TITLE
Introduce B011

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,9 @@ ahead of time.
 property access: ``x.attr = val``. There is no additional safety in
 using ``setattr`` if you know the attribute name ahead of time.
 
+**B011**: Do not call `assert False` since `python -O` removes these calls.
+Instead callers should `raise AssertionError()`.
+
 
 Python 3 compatibility warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -208,6 +208,10 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b007(node)
         self.generic_visit(node)
 
+    def visit_Assert(self, node):
+        self.check_for_b011(node)
+        self.generic_visit(node)
+
     def visit_AsyncFunctionDef(self, node):
         self.check_for_b902(node)
         self.check_for_b006(node)
@@ -272,6 +276,10 @@ class BugBearVisitor(ast.NodeVisitor):
         for name in sorted(ctrl_names - used_names):
             n = targets.names[name][0]
             self.errors.append(B007(n.lineno, n.col_offset, vars=(name,)))
+
+    def check_for_b011(self, node):
+        if isinstance(node.test, ast.NameConstant) and node.test.value is False:
+            self.errors.append(B011(node.lineno, node.col_offset))
 
     def check_for_b901(self, node):
         xs = list(node.body)
@@ -493,6 +501,10 @@ B009 = Error(
 B010 = Error(
     message="B010 Do not call setattr with a constant attribute value, "
     "it is not any safer than normal property access."
+)
+B011 = Error(
+    message="B011 Do not call assert False since python -O removes these calls. "
+            "Instead callers should raise AssertionError()."
 )
 
 

--- a/tests/b011.py
+++ b/tests/b011.py
@@ -1,0 +1,10 @@
+"""
+Should emit:
+B011 - on line 8
+B011 - on line 10
+"""
+
+assert 1 != 2
+assert False
+assert 1 != 2, "message"
+assert False, "message"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -14,6 +14,7 @@ from bugbear import (
     B008,
     B009,
     B010,
+    B011,
     B301,
     B302,
     B303,
@@ -109,6 +110,15 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         self.assertEqual(errors, self.errors(B009(15, 0), B010(22, 0)))
+
+    def test_b011(self):
+        filename = Path(__file__).absolute().parent / 'b011.py'
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(B011(8, 0, vars=('i',)), B011(10, 0, vars=('k',))),
+        )
 
     def test_b301_b302_b305(self):
         filename = Path(__file__).absolute().parent / "b301_b302_b305.py"


### PR DESCRIPTION
Do not call `assert False` since `python -O` removes these calls.  Instead
callers should `raise AssertionError()`.