### PR TITLE
Exclude immutable calls like tuple() and frozenset() from B008

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -246,7 +246,7 @@ class BugBearVisitor(ast.NodeVisitor):
                 call_path = ".".join(self.compose_call_path(default.func))
                 if call_path in B006.mutable_calls:
                     self.errors.append(B006(default.lineno, default.col_offset))
-                else:
+                elif call_path not in B008.immutable_calls:
                     self.errors.append(B008(default.lineno, default.col_offset))
 
     def check_for_b007(self, node):
@@ -470,6 +470,10 @@ B008 = Error(
     "this is intended, assign the function call to a module-level "
     "variable and use that variable as a default value."
 )
+B008.immutable_calls = {
+    'tuple',
+    'frozenset',
+}
 
 
 # Those could be false positives but it's more dangerous to let them slip

--- a/tests/b006_b008.py
+++ b/tests/b006_b008.py
@@ -7,6 +7,10 @@ def this_is_okay(value=(1, 2, 3)):
     ...
 
 
+def and_this_also(value=tuple()):
+    pass
+
+
 def this_is_wrong(value=[1, 2, 3]):
     ...
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -78,13 +78,13 @@ class BugbearTestCase(unittest.TestCase):
         self.assertEqual(
             errors,
             self.errors(
-                B006(10, 24),
-                B006(14, 29),
-                B006(18, 19),
+                B006(14, 24),
+                B006(18, 29),
                 B006(22, 19),
-                B006(26, 31),
-                B008(35, 38),
-                B006(49, 32),
+                B006(26, 19),
+                B006(30, 31),
+                B008(39, 38),
+                B006(53, 32),
             ),
         )
 


### PR DESCRIPTION
Uncommon to see this but these calls are OK as default argument nodes