### PR TITLE
add __class_getitem__ as implicit class method

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -549,7 +549,7 @@ B902 = Error(
     message="B902 Invalid first argument {} used for {} method. Use the "
     "canonical first argument name in methods, i.e. {}."
 )
-B902.implicit_classmethods = {"__new__", "__init_subclass__"}
+B902.implicit_classmethods = {"__new__", "__init_subclass__", "__class_getitem__"}
 B902.self = ["self"]  # it's a list because the first is preferred
 B902.cls = ["cls", "klass"]  # ditto.
 B902.metacls = ["metacls", "metaclass", "typ"]  # ditto.

--- a/tests/b902.py
+++ b/tests/b902.py
@@ -85,3 +85,14 @@ class CrazyBases(Warnings, type_factory(), metaclass=type):
 class RuntimeError("This is not a base"):
     def __init__(self):
         ...
+
+
+class ImplicitClassMethods:
+    def __new__(cls, *args, **kwargs):
+        ...
+
+    def __init_subclass__(cls, *args, **kwargs):
+        ...
+
+    def __class_getitem__(cls, key):
+        ...


### PR DESCRIPTION
Add `__class_getitem__` as implicit class method.

This method was introduced by [PEP 560 into Python 3.7](https://www.python.org/dev/peps/pep-0560/).