### PR TITLE
Remove unused shebang from bugbear.py

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import ast
 from collections import namedtuple
 from contextlib import suppress


### PR DESCRIPTION
1. The file does not have executable permission, so the shebang is never
evaluated.

2. The file is not installed as a command line entry point, but as a
flake8 extensions.

3. `bugbear.py` does not have any standalone side effects. It defines a
class, but does not run any code at the top-level. For example,
running::

```
python bugbear.py
```

Has no permanent side effects.