### PR TITLE
allow 'mcs' for metaclass classmethod first arg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,12 @@ MIT
 Change Log
 ----------
 
+19.3.0
+~~~~~~
+
+* For B902, the first argument for metaclass class methods can be
+  "mcs", matching the name preferred by PyCharm.
+
 18.2.0
 ~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -552,7 +552,7 @@ B902 = Error(
 B902.implicit_classmethods = {"__new__", "__init_subclass__"}
 B902.self = ["self"]  # it's a list because the first is preferred
 B902.cls = ["cls", "klass"]  # ditto.
-B902.metacls = ["metacls", "metaclass", "typ"]  # ditto.
+B902.metacls = ["metacls", "metaclass", "typ", "mcs"]  # ditto.
 
 B903 = Error(
     message="B903 Data class should either be immutable or use __slots__ to "

--- a/tests/b902.py
+++ b/tests/b902.py
@@ -72,6 +72,10 @@ class OtherMeta(type):
     def __prepare__(cls, name, bases):
         return {}
 
+    @classmethod
+    def first_arg_mcs_allowed(mcs, value):
+        ...
+
 
 def type_factory():
     return object
@@ -85,3 +89,4 @@ class CrazyBases(Warnings, type_factory(), metaclass=type):
 class RuntimeError("This is not a base"):
     def __init__(self):
         ...
+


### PR DESCRIPTION
PyCharm's inspector wants the first arg of metaclass class methods to be called "mcs", it will complain if it's called "metacls" or any of the names Bugbear currently allows. I'd like to be able to satisfy both PyCharm and Bugbear. Since there dosen't appear to be a source of truth for this list of allowed names, I felt it was OK to add this one.