### PR TITLE
Check shebang and file executability.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,10 @@ using ``setattr`` if you know the attribute name ahead of time.
 **B011**: Do not call `assert False` since `python -O` removes these calls.
 Instead callers should `raise AssertionError()`.
 
+**B012**: Shebang is present but the file is not executable.
+
+**B013**: The file is executable but no shebang is present.
+
 
 Python 3 compatibility warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/b012.py
+++ b/tests/b012.py
@@ -1,0 +1,4 @@
+#!/usr/bin/python
+
+if __name__ == '__main__':
+    print('I should be executable.')

--- a/tests/b013.py
+++ b/tests/b013.py
@@ -1,0 +1,2 @@
+def a_lib_function():
+    print("I shouldn't be executable.")

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -15,6 +15,8 @@ from bugbear import (
     B009,
     B010,
     B011,
+    B012,
+    B013,
     B301,
     B302,
     B303,
@@ -118,6 +120,24 @@ class BugbearTestCase(unittest.TestCase):
         self.assertEqual(
             errors,
             self.errors(B011(8, 0, vars=('i',)), B011(10, 0, vars=('k',))),
+        )
+
+    def test_b012(self):
+        filename = Path(__file__).absolute().parent / 'b012.py'
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(B012(1, 0))
+        )
+
+    def test_b013(self):
+        filename = Path(__file__).absolute().parent / 'b013.py'
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(B013(1, 0))
         )
 
     def test_b301_b302_b305(self):


### PR DESCRIPTION
- B012: There is a shebang in a Python file but the file is not executable. The developer may have forgotten to make it executable.
- B013: A Python file is executable but there is no shebang in it. This is quite common because very often developers make a file executable without noticing it (e.g., when using some unzip programs).