### PR TITLE
Use adjusted_max_length in error message

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -45,8 +45,9 @@ class BugBearChecker:
         """
         for lineno, line in enumerate(self.lines, start=1):
             length = len(line) - 1
-            if length > 1.1 * self.max_line_length:
-                yield B950(lineno, length, vars=(length, self.max_line_length))
+            adjusted_max_length = round(1.1 * self.max_line_length)
+            if length > adjusted_max_length:
+                yield B950(lineno, length, vars=(length, adjusted_max_length))
 
     @classmethod
     def adapt_error(cls, e):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -188,7 +188,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b950.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B950(6, 92, vars=(92, 79))))
+        self.assertEqual(errors, self.errors(B950(6, 92, vars=(92, 87))))
 
     def test_selfclean_bugbear(self):
         filename = Path(__file__).absolute().parent.parent / "bugbear.py"


### PR DESCRIPTION
Fixes https://github.com/PyCQA/flake8-bugbear/issues/67

Rounded the value to avoid an error message that included a float as the max line length.