### PR TITLE
Add explanation for not including lints in main lint tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,12 @@ pycodestyle::
     3. A fearsome imaginary creature, especially one evoked to frighten
        children.
 
+It is felt that these lints don't belong in the main Python tools as they
+are very opinionated and do not have a PEP or standard behind them. Due to
+``flake8`` being designed to be extensible, the original creators of these lints
+believed that a plugin was the best route. This has resulted in better development
+velocity for contributors and adaptive deployment for ``flake8`` users.
+
 Installation
 ------------
 


### PR DESCRIPTION
- Explain lints are opinionated and not standards
- Explain flake8 plugin design as the other reason

Fixes #92