### PR TITLE
Removed a colon from the descriptive message in B008.

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -497,7 +497,7 @@ B007 = Error(
     "If this is intended, start the name with an underscore."
 )
 B008 = Error(
-    message="B008: Do not perform function calls in argument defaults.  The call is "
+    message="B008 Do not perform function calls in argument defaults.  The call is "
     "performed only once at function definition time. All calls to your "
     "function will reuse the result of that definition-time function call.  If "
     "this is intended, assign the function call to a module-level variable and "

--- a/tests/b901.py
+++ b/tests/b901.py
@@ -62,7 +62,7 @@ def not_broken6():
 
 
 def not_broken7():
-    x = (yield from [])
+    x = yield from []
     return x
 
 


### PR DESCRIPTION
Hey! We are using bugbear wrapped inside a tool which parses flake8 messages for our code. There was a colon after B008, which we found when our parsing didn't look quite right. The colon was also inconsistent with the other flake8 messages... so this is a little PR that removes it.

Thanks! Great plugin!