### PR TITLE
Warn about continue/return/break in finally block

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,11 @@ using ``setattr`` if you know the attribute name ahead of time.
 **B011**: Do not call `assert False` since `python -O` removes these calls.
 Instead callers should `raise AssertionError()`.
 
+**B012**: Use of `break`, `continue` or `return` inside `finally` blocks will
+silence exceptions or override return values from the `try` or `except` blocks.
+To silence an exception, do it explicitly in the `except` block. To properly use
+a `break`, `continue` or `return` refactor your code so these statements are not
+in the `finally` block.
 
 Python 3 compatibility warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/b012.py
+++ b/tests/b012.py
@@ -1,0 +1,95 @@
+def a():
+    try:
+        pass
+    finally:
+        return  # warning
+
+
+def b():
+    try:
+        pass
+    finally:
+        if 1 + 0 == 2 - 1:
+            return  # warning
+
+
+def c():
+    try:
+        pass
+    finally:
+        try:
+            return  # warning
+        except Exception:
+            pass
+
+
+def d():
+    try:
+        try:
+            pass
+        finally:
+            return  # warning
+    finally:
+        pass
+
+
+def e():
+    if 1 == 2 - 1:
+        try:
+
+            def f():
+                try:
+                    pass
+                finally:
+                    return  # warning
+
+        finally:
+            pass
+
+
+def g():
+    try:
+        pass
+    finally:
+
+        def h():
+            return  # no warning
+
+        e()
+
+
+def i():
+    while True:
+        try:
+            pass
+        finally:
+            break  # warning
+
+            def j():
+                while True:
+                    break  # no warning
+
+
+def h():
+    while True:
+        try:
+            pass
+        finally:
+            continue  # warning
+
+            def j():
+                while True:
+                    continue  # no warning
+
+
+while True:
+    try:
+        pass
+    finally:
+        continue  # warning
+
+while True:
+    try:
+        pass
+    finally:
+        break  # warning

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -15,6 +15,7 @@ from bugbear import (
     B009,
     B010,
     B011,
+    B012,
     B301,
     B302,
     B303,
@@ -118,6 +119,23 @@ class BugbearTestCase(unittest.TestCase):
         self.assertEqual(
             errors, self.errors(B011(8, 0, vars=("i",)), B011(10, 0, vars=("k",)))
         )
+
+    def test_b012(self):
+        filename = Path(__file__).absolute().parent / "b012.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        all_errors = [
+            B012(5, 8),
+            B012(13, 12),
+            B012(21, 12),
+            B012(31, 12),
+            B012(44, 20),
+            B012(66, 12),
+            B012(78, 12),
+            B012(89, 8),
+            B012(95, 8),
+        ]
+        self.assertEqual(errors, self.errors(*all_errors))
 
     def test_b301_b302_b305(self):
         filename = Path(__file__).absolute().parent / "b301_b302_b305.py"


### PR DESCRIPTION
Context:
Fixes : #99 

The new warning has code B012 and is enabled by default.

Bonus: refactored `check_for_b901()` to just use a recursive loop since I was initially trying to reuse that function, but turned out to be messy.