### PR TITLE
Cleanup CI + Remove 3.5 Classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,16 @@ matrix:
   include:
     - python: 3.6
     - python: 3.7
-    - python: 3.8-dev
+    - python: 3.8
     - python: nightly
   allow_failures:
-    - python: 3.8-dev
     - python: nightly
 
 install:
-  - pip install --upgrade pip setuptools black
+  - pip install --upgrade pip setuptools coverage black
   - pip install .
 
 script:
-  - python setup.py test && find . -type f -name '*.py' | xargs black --check
+  - coverage run tests/test_bugbear.py
+  - coverage report -m | grep 'bugbear\.py'
+  - black --check .

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 import sys
 
 
-assert sys.version_info >= (3, 5, 0), "bugbear requires Python 3.5+"
+assert sys.version_info >= (3, 6, 0), "bugbear requires Python 3.6+"
 
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -37,7 +37,7 @@ setup(
     license="MIT",
     py_modules=["bugbear"],
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=["flake8 >= 3.0.0", "attrs"],
     test_suite="tests.test_bugbear",
     classifiers=[
@@ -49,9 +49,9 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",


### PR DESCRIPTION
- Use official 3.8 release
- Run tests via coverage + show coverage (setuptools has deprecated test option)
- Use black's recursive file finding abilities

Fixes #95