### PR TITLE
Fix error on attributes-of-attributes in `except (...):` clauses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: nightly
 
 install:
-  - pip install --upgrade pip setuptools coverage black
+  - pip install --upgrade pip setuptools coverage black hypothesmith
   - pip install -e .
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     py_modules=["bugbear"],
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["flake8 >= 3.0.0", "attrs"],
+    install_requires=["flake8 >= 3.0.0", "attrs>=19.2.0"],
     test_suite="tests.test_bugbear",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tests/b013.py
+++ b/tests/b013.py
@@ -28,3 +28,9 @@ try:
 except (re.error,):
     # pointless use of tuple with dotted attribute
     pass
+
+try:
+    pass
+except (a.b.c.d, b.c.d):
+    # attribute of attribute, etc.
+    pass


### PR DESCRIPTION
CC @cooperlees and @AlexandreYang 

As well as fixing the bug, I've added some fuzz-tests that should catch any similar issues before release next time.  
(in this case they don't, meaning that (a) I need to improve Hypothesmith, and (b) there is no affected code in the standard library or any third-party packages in my dev environment.  Rare bug!)