### PR TITLE
Silence B009/B010 for non-identifiers

### DIFF
--- a/tests/b009_b010.py
+++ b/tests/b009_b010.py
@@ -1,7 +1,7 @@
 """
 Should emit:
-B009 - Line 15
-B010 - Line 22
+B009 - Line 16, 17, 18
+B010 - Line 26, 27, 28
 """
 
 # Valid getattr usage
@@ -10,13 +10,19 @@ getattr(foo, "bar", None)
 getattr(foo, "bar{foo}".format(foo="a"), None)
 getattr(foo, "bar{foo}".format(foo="a"))
 getattr(foo, bar, None)
+getattr(foo, "123abc")
 
 # Invalid usage
 getattr(foo, "bar")
+getattr(foo, "_123abc")
+getattr(foo, "abc123")
 
 # Valid setattr usage
 setattr(foo, bar, None)
 setattr(foo, "bar{foo}".format(foo="a"), None)
+setattr(foo, "123abc", None)
 
 # Invalid usage
 setattr(foo, "bar", None)
+setattr(foo, "_123abc", None)
+setattr(foo, "abc123", None)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -123,7 +123,15 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b009_b010.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B009(15, 0), B010(22, 0)))
+        all_errors = [
+            B009(16, 0),
+            B009(17, 0),
+            B009(18, 0),
+            B010(26, 0),
+            B010(27, 0),
+            B010(28, 0),
+        ]
+        self.assertEqual(errors, self.errors(*all_errors))
 
     def test_b011(self):
         filename = Path(__file__).absolute().parent / "b011.py"


### PR DESCRIPTION
If an object implements `__getattr__` and/or `__setattr__`, the second parameter to a `getattr()` or `setattr()` call might not be a valid Python identifier (e.g. `getattr(foo, "123abc")`). In this case bugbear should not emit B009/B010, since changing to `foo.123abc` would be a SyntaxError. Update the B009/B010 detection to check using a regex.

Fixes #113.