### PR TITLE
Don't emit B009/B010 for keywords

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from contextlib import suppress
 from functools import lru_cache, partial
 import itertools
+from keyword import iskeyword
 import logging
 import re
 
@@ -225,12 +226,14 @@ class BugBearVisitor(ast.NodeVisitor):
                     node.func.id == "getattr"
                     and len(node.args) == 2  # noqa: W503
                     and _is_identifier(node.args[1])  # noqa: W503
+                    and not iskeyword(node.args[1].s)  # noqa: W503
                 ):
                     self.errors.append(B009(node.lineno, node.col_offset))
                 elif (
                     node.func.id == "setattr"
                     and len(node.args) == 3  # noqa: W503
                     and _is_identifier(node.args[1])  # noqa: W503
+                    and not iskeyword(node.args[1].s)  # noqa: W503
                 ):
                     self.errors.append(B010(node.lineno, node.col_offset))
 

--- a/tests/b009_b010.py
+++ b/tests/b009_b010.py
@@ -1,7 +1,7 @@
 """
 Should emit:
-B009 - Line 16, 17, 18
-B010 - Line 26, 27, 28
+B009 - Line 17, 18, 19
+B010 - Line 28, 29, 30
 """
 
 # Valid getattr usage
@@ -11,6 +11,7 @@ getattr(foo, "bar{foo}".format(foo="a"), None)
 getattr(foo, "bar{foo}".format(foo="a"))
 getattr(foo, bar, None)
 getattr(foo, "123abc")
+getattr(foo, "except")
 
 # Invalid usage
 getattr(foo, "bar")
@@ -21,6 +22,7 @@ getattr(foo, "abc123")
 setattr(foo, bar, None)
 setattr(foo, "bar{foo}".format(foo="a"), None)
 setattr(foo, "123abc", None)
+getattr(foo, "except", None)
 
 # Invalid usage
 setattr(foo, "bar", None)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -124,12 +124,12 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         all_errors = [
-            B009(16, 0),
             B009(17, 0),
             B009(18, 0),
-            B010(26, 0),
-            B010(27, 0),
+            B009(19, 0),
             B010(28, 0),
+            B010(29, 0),
+            B010(30, 0),
         ]
         self.assertEqual(errors, self.errors(*all_errors))
 


### PR DESCRIPTION
I wrote an argparse CLI with option named `except` - the code works fine with `getattr(ns, "except")`, but `ns.except` is a SyntaxError.  So this patch makes the linter keyword-aware :smile: 