### PR TITLE
Add Development instructions + dev extra requires

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = bugbear

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ matrix:
     - python: nightly
 
 install:
-  - pip install --upgrade pip setuptools coverage black hypothesmith
-  - pip install -e .
+  - pip install --upgrade pip setuptools wheel
+  - pip install -e .[dev]
 
 script:
   - coverage run tests/test_bugbear.py
-  - coverage report -m | grep 'bugbear\.py'
+  - coverage report -m
   - black --check .

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,59 @@
+# flake8-bugbear development
+
+So you want to help out? **Awesome**. Go you!
+
+## Getting Started
+
+We use GitHub. To get started I'd suggest visiting https://guides.github.com/
+
+### Pre Install
+
+Please make sure you system has the following:
+
+- Python 3.6.0 or greater
+- git cli client
+
+Also ensure you can authenticate with GitHub via SSH Keys or HTTPS.
+
+### Checkout `flake8-bugbear`
+
+Lets now cd to where we want the code and clone the repo:
+
+Remember to fork the repo for your PR via the UI or other means (cli).
+
+- `cd somewhere`
+- `git clone git@github.com:YOUR_USERNAME/flake8-bugbear.git`
+
+### Development venv
+
+One way to develop and install all the dependencies is to use a venv.
+
+- Lets create one and upgrade `pip`
+
+```console
+python3 -m venv /path/to/venv
+/path/to/venv/bin/pip install --upgrade pip setuptools wheel
+```
+
+- Then we install flake8-bugbeaer with the dev dependencies
+
+```console
+cd flake8-bugbear
+/path/to/venv/bin/pip install -e .[dev]
+```
+
+## Running Tests
+
+flake8-bugbear uses coverage to run standard unittest tests.
+
+```console
+/path/to/venv/bin/coverage run tests/test_bugbear.py
+```
+
+## Running black
+
+We also format with black. Please ensure you `black` format your PR.
+
+```console
+/path/to/venv/bin/black .
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ python3 -m venv /path/to/venv
 /path/to/venv/bin/pip install --upgrade pip setuptools wheel
 ```
 
-- Then we install flake8-bugbeaer with the dev dependencies
+- Then we install flake8-bugbear with the dev dependencies
 
 ```console
 cd flake8-bugbear

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,11 @@ been picked up with:
     $ flake8 --version
     3.5.0 (assertive: 1.0.1, flake8-bugbear: 18.2.0, flake8-comprehensions: 1.4.1, mccabe: 0.6.1, pycodestyle: 2.3.1, pyflakes: 1.6.0) CPython 3.7.0 on Darwin
 
+Development
+-----------
+
+If you'd like to do a PR we have development instructions `here <https://github.com/PyCQA/flake8-bugbear/blob/master/DEVELOPMENT.md>`_.
+
 List of warnings
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,6 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
     ],
     entry_points={"flake8.extension": ["B = bugbear:BugBearChecker"]},
+    extras_require={"dev": ["coverage", "black", "hypothesis", "hypothesmith"]},
     project_urls={"Change Log": "https://github.com/PyCQA/flake8-bugbear#change-log"},
 )


### PR DESCRIPTION
- Instruct people how to run our tests
- Add .coveragerc to only show coverage for bugbear.py
- Update setup.py to have a dev extras require to make development installing easier
- Update CI to use new dev extras install

Test:
- Follow my own documentation:
```
cooper-mbp1:flake8-bugbear cooper$ /tmp/tbb/bin/coverage run tests/test_bugbear.py
.......................
----------------------------------------------------------------------
Ran 23 tests in 5.593s

OK
```