### PR TITLE
Support exception aliases properly in B014

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -174,6 +174,7 @@ class BugBearVisitor(ast.NodeVisitor):
                 #    (MyError, MyError)  # duplicate names
                 #    (MyError, BaseException)  # everything derives from the Base
                 #    (Exception, TypeError)  # builtins where one subclasses another
+                #    (IOError, OSError)  # IOError is an alias of OSError since Python3.3
                 # but note that other cases are impractical to hande from the AST.
                 # We expect this is mostly useful for users who do not have the
                 # builtin exception hierarchy memorised, and include a 'shadowed'
@@ -181,6 +182,16 @@ class BugBearVisitor(ast.NodeVisitor):
                 good = sorted(set(names), key=names.index)
                 if "BaseException" in good:
                     good = ["BaseException"]
+                # Find and remove aliases exceptions and only leave the primary alone
+                primaries = [
+                    primary
+                    for primary in B014.exception_aliases.keys()
+                    if primary in good
+                ]
+                for primary in primaries:
+                    aliases = B014.exception_aliases[primary]
+                    good = [e for e in good if e not in aliases]
+
                 for name, other in itertools.permutations(tuple(good), 2):
                     if issubclass(
                         getattr(builtins, name, type), getattr(builtins, other, ())
@@ -639,6 +650,16 @@ B014 = Error(
         "Write `except {2}{1}:`, which catches exactly the same exceptions."
     )
 )
+B014.exception_aliases = {
+    "OSError": {
+        "IOError",
+        "EnvironmentError",
+        "WindowsError",
+        "mmap.error",
+        "socket.error",
+        "select.error",
+    }
+}
 
 # Those could be false positives but it's more dangerous to let them slip
 # through if they're not.

--- a/bugbear.py
+++ b/bugbear.py
@@ -183,14 +183,12 @@ class BugBearVisitor(ast.NodeVisitor):
                 if "BaseException" in good:
                     good = ["BaseException"]
                 # Find and remove aliases exceptions and only leave the primary alone
-                primaries = [
-                    primary
-                    for primary in B014.exception_aliases.keys()
-                    if primary in good
-                ]
+                primaries = filter(
+                    lambda primary: primary in good, B014.exception_aliases.keys()
+                )
                 for primary in primaries:
                     aliases = B014.exception_aliases[primary]
-                    good = [e for e in good if e not in aliases]
+                    good = list(filter(lambda e: e not in aliases, good))
 
                 for name, other in itertools.permutations(tuple(good), 2):
                     if issubclass(

--- a/tests/b014.py
+++ b/tests/b014.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B014 - on lines 10, 16, 27, 41, and 48
+B014 - on lines 10, 16, 27, 41, 48, and 55
 """
 
 import re
@@ -47,4 +47,15 @@ try:
     pass
 except (re.error, re.error):
     # Duplicate exception types as attributes
+    pass
+
+
+try:
+    pass
+except (IOError, EnvironmentError, OSError):
+    # Detect if a primary exception and any its aliases are present.
+    #
+    # Since Python 3.3, IOError, EnvironmentError, WindowsError, mmap.error,
+    # socket.error and select.error are aliases of OSError. See PEP 3151 for
+    # more info.
     pass

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -178,6 +178,7 @@ class BugbearTestCase(unittest.TestCase):
             B014(27, 0, vars=("MyError, MyError", "", "MyError")),
             B014(41, 0, vars=("MyError, BaseException", " as e", "BaseException")),
             B014(48, 0, vars=("re.error, re.error", "", "re.error")),
+            B014(55, 0, vars=("IOError, EnvironmentError, OSError", "", "OSError"),),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Resolves #110 
Resolves #126

```console
(env) richard-26@ubuntu-laptop:~/programming/flake8-bugbear$ cat test.py
try:
    with open("bugbear.py") as f:
        lines = f.readlines()
except (OSError, IOError):
    pass
(env) richard-26@ubuntu-laptop:~/programming/flake8-bugbear$ flake8 test.py
test.py:4:1: B014 Redundant exception types in `except (OSError, IOError):`.  Write `except OSError:`, which catches exactly the same exceptions.
```