### PR TITLE
Add B015: pointless statement.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,9 @@ instead of ``except (SomeError,):``.
 **B014**: Redundant exception types in ``except (Exception, TypeError):``.
 Write ``except Exception:``, which catches exactly the same exceptions.
 
+**B015**: Pointless comparison. This comparison does nothing but
+wastes CPU instructions. Remove it.
+
 
 Python 3 compatibility warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/b015.py
+++ b/tests/b015.py
@@ -1,0 +1,29 @@
+"""
+Should emit:
+B015 - on lines 8, 12, 22, 29
+"""
+
+assert 1 == 1
+
+1 == 1
+
+assert 1 in (1, 2)
+
+1 in (1, 2)
+
+
+if 1 == 2:
+    pass
+
+
+def test():
+    assert 1 in (1, 2)
+
+    1 in (1, 2)
+
+
+data = [x for x in [1, 2, 3] if x in (1, 2)]
+
+
+class TestClass:
+    1 == 1

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -24,6 +24,7 @@ from bugbear import (
     B012,
     B013,
     B014,
+    B015,
     B301,
     B302,
     B303,
@@ -180,6 +181,13 @@ class BugbearTestCase(unittest.TestCase):
             B014(48, 0, vars=("re.error, re.error", "", "re.error")),
             B014(55, 0, vars=("IOError, EnvironmentError, OSError", "", "OSError"),),
         )
+        self.assertEqual(errors, expected)
+
+    def test_b015(self):
+        filename = Path(__file__).absolute().parent / "b015.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(B015(8, 0), B015(12, 0), B015(22, 4), B015(29, 4))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):


### PR DESCRIPTION
For me the main reason to have such check is pytest style asserts, they are quite easy to miss in the middle of the test function

```python
def test_number of objects():
    ...setup code ...
    MyModel.objects.count() == 2   # should be `assert MyModel.objects.count() == 2`
    ...more asserts...
```

so tests are green and developer thinks he's asserted important results in the test.

Pylint has similar rule *pointless-statement* although it's more advanced but it's a pain to run pylint on tests and not all developers can tolerate false positives from it, so I think it would be a good addition to the flake8-bugbear.

Right now that rule checks only comparisons so maybe error should be: "pointless comparison" or we may try to make the rule more complete by including other cases, eg. uncalled functions:

```python
service = Service()
service.run  # should be service.run()
...
```