### PR TITLE
Add check for raising a literal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,9 @@ Write ``except Exception:``, which catches exactly the same exceptions.
 **B015**: Pointless comparison. This comparison does nothing but
 wastes CPU instructions. Remove it.
 
+**B016**: Cannot raise a literal. Did you intend to return it or raise
+an Exception?
+
 
 Python 3 compatibility warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -245,6 +248,11 @@ MIT
 
 Change Log
 ----------
+
+Next version
+~~~~~~~~~~~~
+
+* Introduce B016 to check for raising a literal. (#141)
 
 20.1.4
 ~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -312,6 +312,10 @@ class BugBearVisitor(ast.NodeVisitor):
     def visit_Compare(self, node):
         self.check_for_b015(node)
 
+    def visit_Raise(self, node):
+        self.check_for_b016(node)
+        self.generic_visit(node)
+
     def compose_call_path(self, node):
         if isinstance(node, ast.Attribute):
             yield from self.compose_call_path(node.value)
@@ -386,6 +390,10 @@ class BugBearVisitor(ast.NodeVisitor):
     def check_for_b015(self, node):
         if isinstance(self.node_stack[-2], ast.Expr):
             self.errors.append(B015(node.lineno, node.col_offset))
+
+    def check_for_b016(self, node):
+        if isinstance(node.exc, (ast.NameConstant, ast.Num, ast.Str)):
+            self.errors.append(B016(node.lineno, node.col_offset))
 
     def walk_function_body(self, node):
         def _loop(parent, node):
@@ -678,6 +686,12 @@ B015 = Error(
     message=(
         "B015 Pointless comparison. This comparison does nothing but wastes "
         "CPU instructions. Remove it."
+    )
+)
+B016 = Error(
+    message=(
+        "B016 Cannot raise a literal. Did you intend to return it or raise "
+        "an Exception?"
     )
 )
 

--- a/tests/b016.py
+++ b/tests/b016.py
@@ -1,0 +1,11 @@
+"""
+Should emit:
+B016 - on lines 6, 7, and 8
+"""
+
+raise False
+raise 1
+raise "string"
+raise Exception(False)
+raise Exception(1)
+raise Exception("string")

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -25,6 +25,7 @@ from bugbear import (
     B013,
     B014,
     B015,
+    B016,
     B301,
     B302,
     B303,
@@ -192,6 +193,13 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(B015(8, 0), B015(12, 0), B015(22, 4), B015(29, 4))
+        self.assertEqual(errors, expected)
+
+    def test_b016(self):
+        filename = Path(__file__).absolute().parent / "b016.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(B016(6, 0), B016(7, 0), B016(8, 0))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):


### PR DESCRIPTION
This is invalid and the user likely intended to return instead.
GitHub code search is not great but shows a few instances of this:

https://github.com/search?l=Python&p=1&q=%22raise+False%22&type=Code