### PR TITLE
make sure float infinity/NaN does not trigger B008

### DIFF
--- a/tests/b006_b008.py
+++ b/tests/b006_b008.py
@@ -66,3 +66,35 @@ def kwonlyargs_immutable(*, value=()):
 
 def kwonlyargs_mutable(*, value=[]):
     ...
+
+
+def float_inf_okay(value=float("inf")):
+    pass
+
+
+def float_infinity_okay(value=float("infinity")):
+    pass
+
+
+def float_plus_infinity_okay(value=float("+infinity")):
+    pass
+
+
+def float_minus_inf_okay(value=float("-inf")):
+    pass
+
+
+def float_nan_okay(value=float("nan")):
+    pass
+
+
+def float_minus_NaN_okay(value=float("-NaN")):
+    pass
+
+
+def float_int_is_wrong(value=float(3)):
+    pass
+
+
+def float_str_not_inf_or_nan_is_wrong(value=float("3.14")):
+    pass

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -104,6 +104,8 @@ class BugbearTestCase(unittest.TestCase):
                 B006(42, 31),
                 B008(51, 38),
                 B006(67, 32),
+                B008(95, 29),
+                B008(99, 44),
             ),
         )
 


### PR DESCRIPTION
This PR addresses issue #154, and make sure float infinity/NaN does not trigger a B008 error.  Some unit tests are added.

I tested this code on Python 3.9, I don't know how to test this on Python 3.7 or below (note that this is needed because the ast
module behavior for constants changed), do you have regressions that check across versions automatically?
