### PR TITLE
Bugfix: Verify the element in item_context.args is of type ast.Name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,13 @@ waste CPU instructions. Either prepend ``assert`` or remove it.
 **B016**: Cannot raise a literal. Did you intend to return it or raise
 an Exception?
 
+**B017**: ``self.assertRaises(Exception):`` should be considered evil. It can lead 
+to your test passing even if the code being tested is never executed due to a typo. 
+Either assert for a more specific exception (builtin or custom), use 
+``assertRaisesRegex``, or use the context manager form of assertRaises
+(``with self.assertRaises(Exception) as ex:``) with an assertion against the
+data available in ``ex``.
+
 
 Python 3 compatibility warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -249,6 +256,11 @@ MIT
 Change Log
 ----------
 
+21.4.1
+~~~~~~
+
+* Add B017: check for gotta-catch-em-all assertRaises(Exception)
+  
 21.3.2
 ~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,11 @@ MIT
 Change Log
 ----------
 
+21.3.2
+~~~~~~
+
+* Fix crash on tuple expansion in try/except block (#161)
+
 21.3.1
 ~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -10,6 +10,7 @@ from functools import lru_cache, partial
 from keyword import iskeyword
 
 import attr
+
 import pycodestyle
 
 __version__ = "21.4.2"
@@ -443,6 +444,7 @@ class BugBearVisitor(ast.NodeVisitor):
             and hasattr(item_context.func, "attr")  # noqa W503
             and item_context.func.attr == "assertRaises"  # noqa W503
             and len(item_context.args) == 1  # noqa W503
+            and isinstance(item_context.args[0], ast.Name)  # noqa W503
             and item_context.args[0].id == "Exception"  # noqa W503
             and not item.optional_vars  # noqa W503
         ):
@@ -468,9 +470,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
         for parent, x in self.walk_function_body(node):
             # Only consider yield when it is part of an Expr statement.
-            if isinstance(parent, ast.Expr) and isinstance(
-                x, (ast.Yield, ast.YieldFrom)
-            ):
+            if isinstance(parent, ast.Expr) and isinstance(x, (ast.Yield, ast.YieldFrom)):
                 has_yield = True
 
             if isinstance(x, ast.Return) and x.value is not None:

--- a/bugbear.py
+++ b/bugbear.py
@@ -12,7 +12,7 @@ from keyword import iskeyword
 import attr
 import pycodestyle
 
-__version__ = "21.3.2"
+__version__ = "21.3.3"
 
 LOG = logging.getLogger("flake8.bugbear")
 
@@ -317,6 +317,10 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b016(node)
         self.generic_visit(node)
 
+    def visit_With(self, node):
+        self.check_for_b017(node)
+        self.generic_visit(node)
+
     def compose_call_path(self, node):
         if isinstance(node, ast.Attribute):
             yield from self.compose_call_path(node.value)
@@ -422,6 +426,26 @@ class BugBearVisitor(ast.NodeVisitor):
     def check_for_b016(self, node):
         if isinstance(node.exc, (ast.NameConstant, ast.Num, ast.Str)):
             self.errors.append(B016(node.lineno, node.col_offset))
+
+    def check_for_b017(self, node):
+        """Checks for use of the evil syntax 'with assertRaises(Exception):'
+
+        This form of assertRaises will catch everything that subclasses
+        Exception, which happens to be the vast majority of Python internal
+        errors, including the ones raised when a non-existing method/function
+        is called, or a function is called with an invalid dictionary key
+        lookup.
+        """
+        item = node.items[0]
+        item_context = item.context_expr
+        if (
+            hasattr(item_context.func, "attr")
+            and item_context.func.attr == "assertRaises"  # noqa W503
+            and len(item_context.args) == 1  # noqa W503
+            and item_context.args[0].id == "Exception"  # noqa W503
+            and not item.optional_vars  # noqa W503
+        ):
+            self.errors.append(B017(node.lineno, node.col_offset))
 
     def walk_function_body(self, node):
         def _loop(parent, node):
@@ -725,6 +749,15 @@ B016 = Error(
     message=(
         "B016 Cannot raise a literal. Did you intend to return it or raise "
         "an Exception?"
+    )
+)
+B017 = Error(
+    message=(
+        "B017 assertRaises(Exception): should be considered evil. "
+        "It can lead to your test passing even if the code being tested is "
+        "never executed due to a typo. Either assert for a more specific "
+        "exception (builtin or custom), use assertRaisesRegex, or use the "
+        "context manager form of assertRaises."
     )
 )
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -12,7 +12,7 @@ from keyword import iskeyword
 import attr
 import pycodestyle
 
-__version__ = "21.3.3"
+__version__ = "21.3.2"
 
 LOG = logging.getLogger("flake8.bugbear")
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -13,7 +13,7 @@ import attr
 
 import pycodestyle
 
-__version__ = "21.4.2"
+__version__ = "21.4.3"
 
 LOG = logging.getLogger("flake8.bugbear")
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -124,8 +124,10 @@ def _to_name_str(node):
     # "pkg.mod.error", handling any depth of attribute accesses.
     if isinstance(node, ast.Name):
         return node.id
-    assert isinstance(node, ast.Attribute)
-    return _to_name_str(node.value) + "." + node.attr
+    try:
+        return _to_name_str(node.value) + "." + node.attr
+    except AttributeError:
+        return _to_name_str(node.value)
 
 
 def _typesafe_issubclass(cls, class_or_tuple):

--- a/bugbear.py
+++ b/bugbear.py
@@ -470,7 +470,9 @@ class BugBearVisitor(ast.NodeVisitor):
 
         for parent, x in self.walk_function_body(node):
             # Only consider yield when it is part of an Expr statement.
-            if isinstance(parent, ast.Expr) and isinstance(x, (ast.Yield, ast.YieldFrom)):
+            if isinstance(parent, ast.Expr) and isinstance(
+                x, (ast.Yield, ast.YieldFrom)
+            ):
                 has_yield = True
 
             if isinstance(x, ast.Return) and x.value is not None:

--- a/bugbear.py
+++ b/bugbear.py
@@ -12,7 +12,7 @@ from keyword import iskeyword
 import attr
 import pycodestyle
 
-__version__ = "21.3.1"
+__version__ = "21.3.2"
 
 LOG = logging.getLogger("flake8.bugbear")
 

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -1,0 +1,20 @@
+"""
+Should emit:
+B017 - on lines 10
+"""
+import unittest
+
+
+class Foobar(unittest.TestCase):
+    def evil_raises(self) -> None:
+        with self.assertRaises(Exception):
+            raise Exception("Evil I say!")
+
+    def context_manager_raises(self) -> None:
+        with self.assertRaises(Exception) as ex:
+            raise Exception("Context manager is good")
+        self.assertEqual("Context manager is good", str(ex.exception))
+
+    def regex_raises(self) -> None:
+        with self.assertRaisesRegex(Exception, "Regex is good"):
+            raise Exception("Regex is good")

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -12,8 +12,10 @@ def something_else() -> None:
     for i in (1, 2, 3):
         print(i)
 
+
 class Foo:
     pass
+
 
 class Foobar(unittest.TestCase):
     def evil_raises(self) -> None:

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -1,9 +1,8 @@
 """
 Should emit:
-B017 - on lines 10
+B017 - on lines 17
 """
 import unittest
-
 
 CONSTANT = True
 

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -1,8 +1,9 @@
 """
 Should emit:
-B017 - on lines 17
+B017 - on lines 20
 """
 import unittest
+import asyncio
 
 CONSTANT = True
 
@@ -11,6 +12,8 @@ def something_else() -> None:
     for i in (1, 2, 3):
         print(i)
 
+class Foo:
+    pass
 
 class Foobar(unittest.TestCase):
     def evil_raises(self) -> None:
@@ -25,3 +28,7 @@ class Foobar(unittest.TestCase):
     def regex_raises(self) -> None:
         with self.assertRaisesRegex(Exception, "Regex is good"):
             raise Exception("Regex is good")
+
+    def raises_with_absolute_reference(self):
+        with self.assertRaises(asyncio.CancelledError):
+            Foo()

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -210,7 +210,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(20, 8))
+        expected = self.errors(B017(22, 8))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -210,7 +210,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(18, 8))
+        expected = self.errors(B017(17, 8))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -210,7 +210,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(17, 8))
+        expected = self.errors(B017(20, 8))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -27,6 +27,7 @@ from bugbear import (
     B014,
     B015,
     B016,
+    B017,
     B301,
     B302,
     B303,
@@ -203,6 +204,13 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(B016(6, 0), B016(7, 0), B016(8, 0))
+        self.assertEqual(errors, expected)
+
+    def test_b017(self):
+        filename = Path(__file__).absolute().parent / "b017.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(B017(10, 8))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -340,6 +340,20 @@ class TestFuzz(unittest.TestCase):
                     if f.endswith(".py"):
                         BugBearChecker(filename=str(Path(dirname) / f))
 
+    def test_does_not_crash_on_tuple_expansion_in_except_statement(self):
+        # akin to test_does_not_crash_on_any_valid_code
+        # but targets a rare case that's not covered by hypothesmith.from_grammar
+        # see https://github.com/PyCQA/flake8-bugbear/issues/153
+        syntax_tree = ast.parse(
+            "grey_list = (ValueError,)\n"
+            "black_list = (TypeError,)\n"
+            "try:\n"
+            "    int('1e3')\n"
+            "except (*grey_list, *black_list):\n"
+            "     print('error caught')"
+        )
+        BugBearVisitor(filename="<string>", lines=[]).visit(syntax_tree)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The sample case that broke the assumptions in the code was doing a module.Error type assertRaises. In this case, item_context.args[0] is now a Call object (without an id attr), not a Name object. So, qualify the conditions even more, and add a test case for the sample provided by @DStape.

Should address #164 