### PR TITLE
Revamp B017 conditionals and expand coverage of problems

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,9 +123,9 @@ waste CPU instructions. Either prepend ``assert`` or remove it.
 **B016**: Cannot raise a literal. Did you intend to return it or raise
 an Exception?
 
-**B017**: ``self.assertRaises(Exception):`` should be considered evil. It can lead 
-to your test passing even if the code being tested is never executed due to a typo. 
-Either assert for a more specific exception (builtin or custom), use 
+**B017**: ``self.assertRaises(Exception):`` should be considered evil. It can lead
+to your test passing even if the code being tested is never executed due to a typo.
+Either assert for a more specific exception (builtin or custom), use
 ``assertRaisesRegex``, or use the context manager form of assertRaises
 (``with self.assertRaises(Exception) as ex:``) with an assertion against the
 data available in ``ex``.
@@ -256,10 +256,15 @@ MIT
 Change Log
 ----------
 
+21.4.4
+~~~~~~
+
+* Rewrite B017 conditional to be more robust, expand coverage
+
 21.4.3
 ~~~~~~
 
-* Verify the element in item_context.args is of type ast.Name for b017 
+* Verify the element in item_context.args is of type ast.Name for b017
 
 21.4.2
 ~~~~~~
@@ -270,7 +275,7 @@ Change Log
 ~~~~~~
 
 * Add B017: check for gotta-catch-em-all assertRaises(Exception)
-  
+
 21.3.2
 ~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -439,7 +439,7 @@ class BugBearVisitor(ast.NodeVisitor):
         lookup.
         """
 
-        def exception_finder(nodes: t.List) -> bool:
+        def exception_finder(nodes: List) -> bool:
             """
             Knows how to handle ast.Tuple or ast.Name elements present in the
             node list.

--- a/bugbear.py
+++ b/bugbear.py
@@ -4,7 +4,7 @@ import itertools
 import logging
 import re
 import sys
-import typing as t
+from typing import List
 from collections import namedtuple
 from contextlib import suppress
 from functools import lru_cache, partial

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -18,7 +18,7 @@ class AssertRaisesThatShouldTrigger(unittest.TestCase):
     def test_tuple_with_Exception(self) -> None:
         """The use of Exception in the tuple will still catch everything"""
         with self.assertRaises((Exception, ValueError)):
-            raise ValueError("Evil I say!")
+            raise TypeError("Evil I say!")
 
     def test_tuple_with_module_and_Exception(self) -> None:
         """The use of Exception in the tuple will still catch everything"""

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -1,9 +1,50 @@
 """
 Should emit:
-B017 - on lines 20
+B017 - on lines 15, 20, 25
+
+All tests are valid unittest syntax, and will work if this code
+is executed.
 """
-import unittest
 import asyncio
+import unittest
+
+
+class AssertRaisesThatShouldTrigger(unittest.TestCase):
+    def test_bare_Exception(self) -> None:
+        """The use of Exception like this will catch everything"""
+        with self.assertRaises(Exception):
+            raise ValueError("Evil I say!")
+
+    def test_tuple_with_Exception(self) -> None:
+        """The use of Exception in the tuple will still catch everything"""
+        with self.assertRaises((Exception, ValueError)):
+            raise ValueError("Evil I say!")
+
+    def test_tuple_with_module_and_Exception(self) -> None:
+        """The use of Exception in the tuple will still catch everything"""
+        with self.assertRaises((Exception, asyncio.CancelledError)):
+            raise ValueError("Evil I say!")
+
+
+class AssertRaisesThatShouldNotTrigger(unittest.TestCase):
+    def test_context_manager_raises(self) -> None:
+        """A context manager being present means someone has probably
+        done a test afterwards; a python linter should have caught the
+        lack of use of 'ex' otherwise"""
+        with self.assertRaises(Exception) as ex:
+            raise ValueError("Context manager is good")
+        self.assertEqual("Context manager is good", str(ex.exception))
+
+    def test_raisesregex(self) -> None:
+        with self.assertRaisesRegex(Exception, "Regex is good"):
+            raise ValueError("Regex is good")
+
+    def test_raises_with_absolute_reference(self):
+        with self.assertRaises(asyncio.CancelledError):
+            raise asyncio.CancelledError()
+
+
+# None of these should trigger the With visitor.
 
 CONSTANT = True
 
@@ -14,23 +55,16 @@ def something_else() -> None:
 
 
 class Foo:
-    pass
+    def __enter__(self, *args, **kwargs) -> None:
+        yield
+
+    def __exit__(self, *args, **kwargs) -> None:
+        ...
 
 
-class Foobar(unittest.TestCase):
-    def evil_raises(self) -> None:
-        with self.assertRaises(Exception):
-            raise Exception("Evil I say!")
+# This may trigger the visitor, but it shouldn't match the filters
+with Foo() as a:
+    print(a)
 
-    def context_manager_raises(self) -> None:
-        with self.assertRaises(Exception) as ex:
-            raise Exception("Context manager is good")
-        self.assertEqual("Context manager is good", str(ex.exception))
-
-    def regex_raises(self) -> None:
-        with self.assertRaisesRegex(Exception, "Regex is good"):
-            raise Exception("Regex is good")
-
-    def raises_with_absolute_reference(self):
-        with self.assertRaises(asyncio.CancelledError):
-            Foo()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -13,17 +13,17 @@ class AssertRaisesThatShouldTrigger(unittest.TestCase):
     def test_bare_Exception(self) -> None:
         """The use of Exception like this will catch everything"""
         with self.assertRaises(Exception):
-            raise ValueError("Evil I say!")
+            print(k["evil"])  # NameError
 
     def test_tuple_with_Exception(self) -> None:
         """The use of Exception in the tuple will still catch everything"""
         with self.assertRaises((Exception, ValueError)):
-            raise TypeError("Evil I say!")
+            print("I can't spell print", indent=1)  # TypeError
 
     def test_tuple_with_module_and_Exception(self) -> None:
         """The use of Exception in the tuple will still catch everything"""
         with self.assertRaises((Exception, asyncio.CancelledError)):
-            raise ValueError("Evil I say!")
+            self.bogus  # AttributeError
 
 
 class AssertRaisesThatShouldNotTrigger(unittest.TestCase):

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -210,7 +210,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(22, 8))
+        expected = self.errors(B017(15, 8), B017(20, 8), B017(25, 8))
         self.assertEqual(errors, expected)
 
     def test_b301_b302_b305(self):


### PR DESCRIPTION
This diff re-addresses #164 by completely rewriting the logic for finding the assertRaises code in the AST.

It also adds support for finding cases of Exception when Exception is in the tuple of things that are being checked by the assertRaises.

Conditional logic was based on output from ast.dump.

For the bare exception case:
```
    context_expr=Call(
        func=Attribute(
            value=Name(id='self', ctx=Load()),
            attr='assertRaises',
            ctx=Load()),
        args=[
            Name(id='Exception', ctx=Load())],
        keywords=[]))
```

For the tuple of builtin exceptions case:
```
    context_expr=Call(
        func=Attribute(
            value=Name(id='self', ctx=Load()),
            attr='assertRaises',
            ctx=Load()),
        args=[
            Tuple(
                elts=[
                    Name(id='Exception', ctx=Load()),
                    Name(id='ValueError', ctx=Load())],
                ctx=Load())],
        keywords=[]))
```

For the tuple of builtin + module exceptions case:
```
    context_expr=Call(
        func=Attribute(
            value=Name(id='self', ctx=Load()),
            attr='assertRaises',
            ctx=Load()),
        args=[
            Tuple(
                elts=[
                    Name(id='Exception', ctx=Load()),
                    Attribute(
                        value=Name(id='asyncio', ctx=Load()),
                        attr='CancelledError',
                        ctx=Load())],
                ctx=Load())],
        keywords=[]))
```

Negative test cases were also checked using ast.dump, and also include other ``with`` syntax.

A sample ast tree for the negative case of a context manager assertRaises:
```
    context_expr=Call(
        func=Attribute(
            value=Name(id='self', ctx=Load()),
            attr='assertRaises',
            ctx=Load()),
        args=[
            Name(id='Exception', ctx=Load())],
        keywords=[]),
    optional_vars=Name(id='ex', ctx=Store()))
```

Examples in the tests/b017.py file are legit broken (or working) code.