### PR TITLE
Add `B904` - Use `raise ... from err` in `except` clauses

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # Keep in sync with setup.cfg which is used for source packages.
 
 [flake8]
-ignore = E203, E302, E501, E999
+ignore = E203, E302, E501, E999, W503
 max-line-length = 88
 max-complexity = 12
 select = B,C,E,F,W,B9

--- a/README.rst
+++ b/README.rst
@@ -123,9 +123,9 @@ waste CPU instructions. Either prepend ``assert`` or remove it.
 **B016**: Cannot raise a literal. Did you intend to return it or raise
 an Exception?
 
-**B017**: ``self.assertRaises(Exception):`` should be considered evil. It can lead 
-to your test passing even if the code being tested is never executed due to a typo. 
-Either assert for a more specific exception (builtin or custom), use 
+**B017**: ``self.assertRaises(Exception):`` should be considered evil. It can lead
+to your test passing even if the code being tested is never executed due to a typo.
+Either assert for a more specific exception (builtin or custom), use
 ``assertRaisesRegex``, or use the context manager form of assertRaises
 (``with self.assertRaises(Exception) as ex:``) with an assertion against the
 data available in ``ex``.
@@ -220,7 +220,7 @@ Change Log
 21.4.3
 ~~~~~~
 
-* Verify the element in item_context.args is of type ast.Name for b017 
+* Verify the element in item_context.args is of type ast.Name for b017
 
 21.4.2
 ~~~~~~
@@ -231,7 +231,7 @@ Change Log
 ~~~~~~
 
 * Add B017: check for gotta-catch-em-all assertRaises(Exception)
-  
+
 21.3.2
 ~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,11 @@ Either assert for a more specific exception (builtin or custom), use
 (``with self.assertRaises(Exception) as ex:``) with an assertion against the
 data available in ``ex``.
 
+**B018**: Within an ``except`` clause, raise exceptions with ``raise ... from err``
+or ``raise ... from None`` to distinguish them from errors in exception handling.
+See [the exception chaining tutorial](https://docs.python.org/3/tutorial/errors.html#exception-chaining)
+for details.
+
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
@@ -216,6 +221,11 @@ MIT
 
 Change Log
 ----------
+
+Future
+~~~~~~
+
+* Add B018: check for ``raise`` without ``from`` in an ``except`` clause
 
 21.4.3
 ~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -130,11 +130,6 @@ Either assert for a more specific exception (builtin or custom), use
 (``with self.assertRaises(Exception) as ex:``) with an assertion against the
 data available in ``ex``.
 
-**B018**: Within an ``except`` clause, raise exceptions with ``raise ... from err``
-or ``raise ... from None`` to distinguish them from errors in exception handling.
-See [the exception chaining tutorial](https://docs.python.org/3/tutorial/errors.html#exception-chaining)
-for details.
-
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
@@ -161,6 +156,11 @@ data classes that only set attributes in an ``__init__`` method, and do
 nothing else. If the attributes should be mutable, define the attributes
 in ``__slots__`` to save per-instance memory and to prevent accidentally
 creating additional attributes on instances.
+
+**B904**: Within an ``except`` clause, raise exceptions with ``raise ... from err``
+or ``raise ... from None`` to distinguish them from errors in exception handling.
+See [the exception chaining tutorial](https://docs.python.org/3/tutorial/errors.html#exception-chaining)
+for details.
 
 **B950**: Line too long. This is a pragmatic equivalent of
 ``pycodestyle``'s E501: it considers "max-line-length" but only triggers
@@ -225,7 +225,7 @@ Change Log
 Future
 ~~~~~~
 
-* Add B018: check for ``raise`` without ``from`` in an ``except`` clause
+* Add B904: check for ``raise`` without ``from`` in an ``except`` clause
 
 21.4.3
 ~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -292,7 +292,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
     def visit_Raise(self, node):
         self.check_for_b016(node)
-        self.check_for_b018(node)
+        self.check_for_b904(node)
         self.generic_visit(node)
 
     def visit_With(self, node):
@@ -427,7 +427,7 @@ class BugBearVisitor(ast.NodeVisitor):
         ):
             self.errors.append(B017(node.lineno, node.col_offset))
 
-    def check_for_b018(self, node):
+    def check_for_b904(self, node):
         """Checks `raise` without `from` inside an `except` clause.
 
         In these cases, you should use explicit exception chaining from the
@@ -440,7 +440,7 @@ class BugBearVisitor(ast.NodeVisitor):
             and not (isinstance(node.exc, ast.Name) and node.exc.id.islower())
             and any(isinstance(n, ast.ExceptHandler) for n in self.node_stack)
         ):
-            self.errors.append(B018(node.lineno, node.col_offset))
+            self.errors.append(B904(node.lineno, node.col_offset))
 
     def walk_function_body(self, node):
         def _loop(parent, node):
@@ -762,13 +762,6 @@ B017 = Error(
         "context manager form of assertRaises."
     )
 )
-B018 = Error(
-    message=(
-        "B018 Within an `except` clause, raise exceptions with `raise ... from err` "
-        "or `raise ... from None` to distinguish them from errors in exception handling.  "
-        "See https://docs.python.org/3/tutorial/errors.html#exception-chaining for details."
-    )
-)
 
 # Warnings disabled by default.
 B901 = Error(
@@ -798,6 +791,14 @@ B903 = Error(
     )
 )
 
+B904 = Error(
+    message=(
+        "B904 Within an `except` clause, raise exceptions with `raise ... from err` "
+        "or `raise ... from None` to distinguish them from errors in exception handling.  "
+        "See https://docs.python.org/3/tutorial/errors.html#exception-chaining for details."
+    )
+)
+
 B950 = Error(message="B950 line too long ({} > {} characters)")
 
-disabled_by_default = ["B901", "B902", "B903", "B950"]
+disabled_by_default = ["B901", "B902", "B903", "B904", "B950"]

--- a/bugbear.py
+++ b/bugbear.py
@@ -434,8 +434,10 @@ class BugBearVisitor(ast.NodeVisitor):
         earlier error, or suppress it with `raise ... from None`.  See
         https://docs.python.org/3/tutorial/errors.html#exception-chaining
         """
-        if node.cause is None and node.exc is not None and any(
-            isinstance(n, ast.ExceptHandler) for n in self.node_stack
+        if (
+            node.cause is None
+            and node.exc is not None
+            and any(isinstance(n, ast.ExceptHandler) for n in self.node_stack)
         ):
             self.errors.append(B018(node.lineno, node.col_offset))
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -437,6 +437,7 @@ class BugBearVisitor(ast.NodeVisitor):
         if (
             node.cause is None
             and node.exc is not None
+            and not (isinstance(node.exc, ast.Name) and node.exc.id.islower())
             and any(isinstance(n, ast.ExceptHandler) for n in self.node_stack)
         ):
             self.errors.append(B018(node.lineno, node.col_offset))

--- a/tests/b018.py
+++ b/tests/b018.py
@@ -1,0 +1,18 @@
+"""
+Should emit:
+B018 - on lines 10, 11 and 16
+"""
+
+try:
+    raise ValueError
+except ValueError:
+    if "abc":
+        raise TypeError
+    raise UserWarning
+except AssertionError:
+    raise  # Bare `raise` should not be an error
+except Exception as err:
+    assert err
+    raise Exception("No cause here...")
+finally:
+    raise Exception("Nothing to chain from, so no warning here")

--- a/tests/b018.py
+++ b/tests/b018.py
@@ -14,5 +14,8 @@ except AssertionError:
 except Exception as err:
     assert err
     raise Exception("No cause here...")
+except BaseException as base_err:
+    # Might use this instead of bare raise with the `.with_traceback()` method
+    raise base_err
 finally:
     raise Exception("Nothing to chain from, so no warning here")

--- a/tests/b904.py
+++ b/tests/b904.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B018 - on lines 10, 11 and 16
+B904 - on lines 10, 11 and 16
 """
 
 try:

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -28,7 +28,7 @@ from bugbear import (
     B015,
     B016,
     B017,
-    B018,
+    B904,
     B901,
     B902,
     B903,
@@ -208,17 +208,6 @@ class BugbearTestCase(unittest.TestCase):
         expected = self.errors(B017(22, 8))
         self.assertEqual(errors, expected)
 
-    def test_b018(self):
-        filename = Path(__file__).absolute().parent / "b018.py"
-        bbc = BugBearChecker(filename=str(filename))
-        errors = list(bbc.run())
-        expected = [
-            B018(10, 8),
-            B018(11, 4),
-            B018(16, 4),
-        ]
-        self.assertEqual(errors, self.errors(*expected))
-
     def test_b901(self):
         filename = Path(__file__).absolute().parent / "b901.py"
         bbc = BugBearChecker(filename=str(filename))
@@ -271,6 +260,17 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         self.assertEqual(errors, self.errors(B903(32, 0), B903(38, 0)))
+
+    def test_b904(self):
+        filename = Path(__file__).absolute().parent / "b904.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = [
+            B904(10, 8),
+            B904(11, 4),
+            B904(16, 4),
+        ]
+        self.assertEqual(errors, self.errors(*expected))
 
     def test_b950(self):
         filename = Path(__file__).absolute().parent / "b950.py"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -28,6 +28,7 @@ from bugbear import (
     B015,
     B016,
     B017,
+    B018,
     B901,
     B902,
     B903,
@@ -206,6 +207,17 @@ class BugbearTestCase(unittest.TestCase):
         errors = list(bbc.run())
         expected = self.errors(B017(22, 8))
         self.assertEqual(errors, expected)
+
+    def test_b018(self):
+        filename = Path(__file__).absolute().parent / "b018.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = [
+            B018(10, 8),
+            B018(11, 4),
+            B018(16, 4),
+        ]
+        self.assertEqual(errors, self.errors(*expected))
 
     def test_b901(self):
         filename = Path(__file__).absolute().parent / "b901.py"


### PR DESCRIPTION
Closes #180, by adding a new check ~~B018~~ B904 to recommend [exception chaining](https://docs.python.org/3/tutorial/errors.html#exception-chaining).  For example,

```python
try:
    assert False
except AssertionError:
    raise RuntimeError  # B904: Within an except clause, use `raise ... from err` ...
```

This turned out to be remarkably easy to add to the existing code 😁 