### PR TITLE
Do not crash on call in except statement

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -125,6 +125,8 @@ def _to_name_str(node):
     # "pkg.mod.error", handling any depth of attribute accesses.
     if isinstance(node, ast.Name):
         return node.id
+    if isinstance(node, ast.Call):
+        return _to_name_str(node.func)
     try:
         return _to_name_str(node.value) + "." + node.attr
     except AttributeError:

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -336,6 +336,14 @@ class TestFuzz(unittest.TestCase):
         )
         BugBearVisitor(filename="<string>", lines=[]).visit(syntax_tree)
 
+    def test_does_not_crash_on_call_in_except_statement(self):
+        # akin to test_does_not_crash_on_tuple_expansion_in_except_statement
+        # see https://github.com/PyCQA/flake8-bugbear/issues/171
+        syntax_tree = ast.parse(
+            "foo = lambda: IOError\ntry:\n    ...\nexcept (foo(),):\n    ...\n"
+        )
+        BugBearVisitor(filename="<string>", lines=[]).visit(syntax_tree)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This fixes the crash reported in issue #171. Not sure if this is the correct way to fix this, but at least it doesn't crash.