### PR TITLE
B904: ensure the raise is in the same context with the except

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -510,7 +510,7 @@ class BugBearVisitor(ast.NodeVisitor):
                 break
 
     def check_for_b902(self, node):
-        if not len(self.contexts) >= 2 or not isinstance(
+        if len(self.contexts) < 2 or not isinstance(
             self.contexts[-2].node, ast.ClassDef
         ):
             return

--- a/bugbear.py
+++ b/bugbear.py
@@ -181,7 +181,7 @@ class BugBearVisitor(ast.NodeVisitor):
     node_window = attr.ib(default=attr.Factory(list))
     errors = attr.ib(default=attr.Factory(list))
     futures = attr.ib(default=attr.Factory(set))
-    context = attr.ib(default=attr.Factory(list))
+    contexts = attr.ib(default=attr.Factory(list))
 
     NODE_WINDOW_SIZE = 4
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -16,6 +16,19 @@ import pycodestyle
 __version__ = "21.9.2"
 
 LOG = logging.getLogger("flake8.bugbear")
+CONTEXTFUL_NODES = (
+    ast.Module,
+    ast.ClassDef,
+    ast.AsyncFunctionDef,
+    ast.FunctionDef,
+    ast.Lambda,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
+)
+
+Context = namedtuple("Context", ["node", "stack"])
 
 
 @attr.s(hash=False)
@@ -147,10 +160,11 @@ def _typesafe_issubclass(cls, class_or_tuple):
 class BugBearVisitor(ast.NodeVisitor):
     filename = attr.ib()
     lines = attr.ib()
-    node_stack = attr.ib(default=attr.Factory(list))
+    contexts = attr.ib(default=attr.Factory(list))
     node_window = attr.ib(default=attr.Factory(list))
     errors = attr.ib(default=attr.Factory(list))
     futures = attr.ib(default=attr.Factory(set))
+    context = attr.ib(default=attr.Factory(list))
 
     NODE_WINDOW_SIZE = 4
 
@@ -161,12 +175,29 @@ class BugBearVisitor(ast.NodeVisitor):
             print(name)
             return self.__getattribute__(name)
 
+    @property
+    def node_stack(self):
+        if len(self.contexts) == 0:
+            return []
+
+        context, stack = self.contexts[-1]
+        return stack
+
     def visit(self, node):
+        is_contextful = isinstance(node, CONTEXTFUL_NODES)
+
+        if is_contextful:
+            context = Context(node, [])
+            self.contexts.append(context)
+
         self.node_stack.append(node)
         self.node_window.append(node)
         self.node_window = self.node_window[-self.NODE_WINDOW_SIZE :]
         super().visit(node)
         self.node_stack.pop()
+
+        if is_contextful:
+            self.contexts.pop()
 
     def visit_ExceptHandler(self, node):
         if node.type is None:
@@ -479,9 +510,12 @@ class BugBearVisitor(ast.NodeVisitor):
                 break
 
     def check_for_b902(self, node):
-        if not isinstance(self.node_stack[-2], ast.ClassDef):
+        if not len(self.contexts) >= 2 or not isinstance(
+            self.contexts[-2].node, ast.ClassDef
+        ):
             return
 
+        cls = self.contexts[-2].node
         decorators = NameFinder()
         decorators.visit(node.decorator_list)
 
@@ -490,7 +524,7 @@ class BugBearVisitor(ast.NodeVisitor):
             # `cls`?
             return
 
-        bases = {b.id for b in self.node_stack[-2].bases if isinstance(b, ast.Name)}
+        bases = {b.id for b in cls.bases if isinstance(b, ast.Name)}
         if "type" in bases:
             if (
                 "classmethod" in decorators.names

--- a/tests/b904.py
+++ b/tests/b904.py
@@ -26,3 +26,27 @@ except ValueError:
     # should not emit, since we are not raising something
     def proxy():
         raise NameError
+
+try:
+    from preferred_library import Thing
+except ImportError:
+    try:
+        from fallback_library import Thing
+    except ImportError:
+        class Thing:
+            def __getattr__(self, name):
+                # same as the case above, should not emit.
+                raise AttributeError
+
+
+try:
+    from preferred_library import Thing
+except ImportError:
+    try:
+        from fallback_library import Thing
+    except ImportError:
+        def context_switch():
+            try:
+                raise ValueError
+            except ValueError:
+                raise Exception

--- a/tests/b904.py
+++ b/tests/b904.py
@@ -19,3 +19,10 @@ except BaseException as base_err:
     raise base_err
 finally:
     raise Exception("Nothing to chain from, so no warning here")
+
+try:
+    raise ValueError
+except ValueError:
+    # should not emit, since we are not raising something
+    def proxy():
+        raise NameError

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -272,6 +272,7 @@ class BugbearTestCase(unittest.TestCase):
             B904(10, 8),
             B904(11, 4),
             B904(16, 4),
+            B904(52, 16),
         ]
         self.assertEqual(errors, self.errors(*expected))
 


### PR DESCRIPTION
Resolves #190. Introduces a simple version of context management, though more detailed analysis might need something a little bit specialized in the future (e.g [stuff like this](https://github.com/isidentical/refactor/blob/1178e9faee21227b5f73f8815724cf9bae048200/refactor/context.py#L165-L177)).