### PR TITLE
replace attrs with dataclass

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,10 @@ setup(
     py_modules=["bugbear"],
     zip_safe=False,
     python_requires=">=3.6",
-    install_requires=["flake8 >= 3.0.0", "attrs>=19.2.0"],
+    install_requires=[
+        "flake8 >= 3.0.0",
+        "dataclasses; python_version == '3.6'",
+    ],
     test_suite="tests.test_bugbear",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR replaces **attrs** with **dataclass**, reducing number of dependencies on Python 3.7+.