### PR TITLE
add simple pre-commit config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,3 @@ jobs:
       run: |
         coverage run tests/test_bugbear.py
         coverage report -m
-
-    - name: Check formatting
-      run: |
-        black --check --experimental-string-processing .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+ci:
+  autofix_prs: false
+
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 21.10b0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,5 @@ repos:
     rev: 21.10b0
     hooks:
       - id: black
+        args:
+        - --experimental-string-processing

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,10 +50,16 @@ flake8-bugbear uses coverage to run standard unittest tests.
 /path/to/venv/bin/coverage run tests/test_bugbear.py
 ```
 
-## Running black
+## Running linter
 
-We also format with black. Please ensure you `black` format your PR.
+We format the code with `black` and `isort`. You can run those using `pre-commit`.
 
 ```console
-/path/to/venv/bin/black .
+pre-commit run --all-files
+```
+
+Or you install the pre-commit hooks to run on every commit:
+
+```console
+pre-commit install
 ```

--- a/bugbear.py
+++ b/bugbear.py
@@ -10,7 +10,6 @@ from functools import lru_cache, partial
 from keyword import iskeyword
 
 import attr
-
 import pycodestyle
 
 __version__ = "21.9.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
     ],
     entry_points={"flake8.extension": ["B = bugbear:BugBearChecker"]},
-    extras_require={"dev": ["coverage", "hypothesis", "hypothesmith", "pre-commit"]},
+    extras_require={
+        "dev": ["coverage", "hypothesis", "hypothesmith>=0.2", "pre-commit"]
+    },
     project_urls={"Change Log": "https://github.com/PyCQA/flake8-bugbear#change-log"},
 )

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 import ast
 import os
 import re
-from setuptools import setup
 import sys
 
+from setuptools import setup
 
 assert sys.version_info >= (3, 6, 0), "bugbear requires Python 3.6+"
 
@@ -60,6 +60,8 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
     ],
     entry_points={"flake8.extension": ["B = bugbear:BugBearChecker"]},
-    extras_require={"dev": ["coverage", "black", "hypothesis", "hypothesmith"]},
+    extras_require={
+        "dev": ["coverage", "black", "hypothesis", "hypothesmith", "pre-commit"]
+    },
     project_urls={"Change Log": "https://github.com/PyCQA/flake8-bugbear#change-log"},
 )

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,6 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
     ],
     entry_points={"flake8.extension": ["B = bugbear:BugBearChecker"]},
-    extras_require={
-        "dev": ["coverage", "black", "hypothesis", "hypothesmith", "pre-commit"]
-    },
+    extras_require={"dev": ["coverage", "hypothesis", "hypothesmith", "pre-commit"]},
     project_urls={"Change Log": "https://github.com/PyCQA/flake8-bugbear#change-log"},
 )

--- a/tests/b003.py
+++ b/tests/b003.py
@@ -3,9 +3,8 @@ Should emit:
 B003 - on line 10
 """
 
-from os import environ
 import os
-
+from os import environ
 
 os.environ = {}
 environ = {}  # that's fine, assigning a new meaning to the module-level name

--- a/tests/b005.py
+++ b/tests/b005.py
@@ -18,7 +18,7 @@ s.rstrip("e")  # no warning
 s.rstrip("\n\t ")  # no warning
 s.rstrip(r"\n\t ")  # warning
 
-from somewhere import strip, other_type
+from somewhere import other_type, strip
 
 strip("we")  # no warning
 other_type().lstrip()  # no warning

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -2,8 +2,8 @@
 Should emit:
 B017 - on lines 20
 """
-import unittest
 import asyncio
+import unittest
 
 CONSTANT = True
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -1,15 +1,14 @@
 import ast
 import os
-from pathlib import Path
 import site
 import subprocess
 import sys
 import unittest
+from pathlib import Path
 
 from hypothesis import HealthCheck, given, settings
 from hypothesmith import from_grammar
 
-from bugbear import BugBearChecker, BugBearVisitor
 from bugbear import (
     B001,
     B002,
@@ -29,11 +28,13 @@ from bugbear import (
     B016,
     B017,
     B018,
-    B904,
     B901,
     B902,
     B903,
+    B904,
     B950,
+    BugBearChecker,
+    BugBearVisitor,
 )
 
 
@@ -64,7 +65,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b003.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        self.assertEqual(errors, self.errors(B003(10, 0)))
+        self.assertEqual(errors, self.errors(B003(9, 0)))
 
     def test_b004(self):
         filename = Path(__file__).absolute().parent / "b004.py"


### PR DESCRIPTION
This PR adds a basic pre-commit config. More pre-commit checks and configuration should be discussed.

To run the checks on a PR you have to give https://pre-commit.ci access to the repository. Checks will then run automatically on the next push

Closes: https://github.com/PyCQA/flake8-bugbear/issues/197