### PR TITLE
Build universal Python 3 wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-python-tag = py36.py37.py38
-
 [flake8]
 # Keep in sync with .flake8. This copy here is needed for source packages
 # to be able to pass tests without failing selfclean check.


### PR DESCRIPTION
Pure Python 3 packages need not include any configuration for `bdist_wheel`. Currently the wheels on PyPI could look to someone new as if they only support Python 3.6-3.8

- https://pypi.org/project/flake8-bugbear/21.11.29/#files

But CI is in fact testing through 3.10:

https://github.com/PyCQA/flake8-bugbear/blob/2095bdd2293b5567ea1dbeb485cab7da13a2e2fe/.github/workflows/ci.yml#L11

Supported Python versions are enforced through:

https://github.com/PyCQA/flake8-bugbear/blob/2095bdd2293b5567ea1dbeb485cab7da13a2e2fe/setup.py#L42

This change will build proper `*-py3-none-any.whl ` wheels.