### PR TITLE
Add B020 check to find for-loop control variable overiding iter set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 .ipynb_checkpoints
 
 .vscode
+
+# JetBrains
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -247,7 +247,7 @@ MIT
 Change Log
 ----------
 
-22.1.27
+Unreleased
 ~~~~~~~~~~
 
 * B020: ensure loop control variable doesn't overrides iterable it iterates (#220)

--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,8 @@ data available in ``ex``.
 
 **B018**: Found useless expression. Either assign it to a variable or remove it.
 
+**B020**: Loop control variable overrides iter set.
+
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ data available in ``ex``.
 
 **B018**: Found useless expression. Either assign it to a variable or remove it.
 
-**B020**: Loop control variable overrides iter set.
+**B020**: Loop control variable overrides iterable it iterates
 
 
 Opinionated warnings

--- a/README.rst
+++ b/README.rst
@@ -247,6 +247,11 @@ MIT
 Change Log
 ----------
 
+22.1.27
+~~~~~~~~~~
+
+* B020: ensure loop control variable doesn't overrides iterable it iterates (#220)
+
 22.1.11
 ~~~~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -333,6 +333,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
     def visit_For(self, node):
         self.check_for_b007(node)
+        self.check_for_b020(node)
         self.generic_visit(node)
 
     def visit_Assert(self, node):
@@ -505,6 +506,20 @@ class BugBearVisitor(ast.NodeVisitor):
             and not item.optional_vars  # noqa W503
         ):
             self.errors.append(B017(node.lineno, node.col_offset))
+
+    def check_for_b020(self, node):
+        targets = NameFinder()
+        targets.visit(node.target)
+        ctrl_names = set(targets.names)
+
+        iterset = NameFinder()
+        iterset.visit(node.iter)
+        iterset_names = set(iterset.names)
+
+        for name in sorted(ctrl_names):
+            if name in iterset_names:
+                n = targets.names[name][0]
+                self.errors.append(B020(n.lineno, n.col_offset, vars=(name,)))
 
     def check_for_b904(self, node):
         """Checks `raise` without `from` inside an `except` clause.
@@ -870,6 +885,9 @@ B018 = Error(
     message=(
         "B018 Found useless expression. Either assign it to a variable or remove it."
     )
+)
+B020 = Error(
+    message="B020 Found for-loop with each item variable reassigning set variable."
 )
 
 # Warnings disabled by default.

--- a/bugbear.py
+++ b/bugbear.py
@@ -887,7 +887,10 @@ B018 = Error(
     )
 )
 B020 = Error(
-    message="B020 Found for loop that reassigns the iterable it is iterating with each iterable value."
+    message=(
+        "B020 Found for loop that reassigns the iterable it is iterating "
+        + "with each iterable value."
+    )
 )
 
 # Warnings disabled by default.

--- a/bugbear.py
+++ b/bugbear.py
@@ -887,7 +887,7 @@ B018 = Error(
     )
 )
 B020 = Error(
-    message="B020 Found for-loop with each item variable reassigning set variable."
+    message="B020 Found for loop that reassigns the iterable it is iterating with each iterable value."
 )
 
 # Warnings disabled by default.

--- a/tests/b020.py
+++ b/tests/b020.py
@@ -1,3 +1,8 @@
+"""
+Should emit:
+B020 - on lines 8 and 21
+"""
+
 items = [1, 2, 3]
 
 for items in items:

--- a/tests/b020.py
+++ b/tests/b020.py
@@ -11,7 +11,7 @@ for item in items:
 values = {"secret": 123}
 
 for key, value in values.items():
-    print(f"{key=}, {value=}")
+    print(f"{key}, {value}")
 
 for key, values in values.items():
-    print(f"{key=}, {values=}")
+    print(f"{key}, {values}")

--- a/tests/b020.py
+++ b/tests/b020.py
@@ -1,0 +1,17 @@
+items = [1, 2, 3]
+
+for items in items:
+    print(items)
+
+items = [1, 2, 3]
+
+for item in items:
+    print(item)
+
+values = {"secret": 123}
+
+for key, value in values.items():
+    print(f"{key=}, {value=}")
+
+for key, values in values.items():
+    print(f"{key=}, {values=}")

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -257,8 +257,8 @@ class BugbearTestCase(unittest.TestCase):
         self.assertEqual(
             errors,
             self.errors(
-                B020(3, 4, vars=("items",)),
-                B020(16, 9, vars=("values",)),
+                B020(8, 4, vars=("items",)),
+                B020(21, 9, vars=("values",)),
             ),
         )
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -29,6 +29,7 @@ from bugbear import (
     B016,
     B017,
     B018,
+    B020,
     B901,
     B902,
     B903,
@@ -248,6 +249,18 @@ class BugbearTestCase(unittest.TestCase):
         expected.append(B018(30, 4))
         expected.append(B018(33, 4))
         self.assertEqual(errors, self.errors(*expected))
+
+    def test_b020(self):
+        filename = Path(__file__).absolute().parent / "b020.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(
+                B020(3, 4, vars=("items",)),
+                B020(16, 9, vars=("values",)),
+            ),
+        )
 
     def test_b901(self):
         filename = Path(__file__).absolute().parent / "b901.py"


### PR DESCRIPTION
# Description
A simple typo of the for-loop control variable name `item => items` in loop `[items for items in items]` can lead to an unintended change of the `items` variable.  

Fixes #219
