### PR TITLE
B021: f-string used as docstring.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,9 @@ data available in ``ex``.
 
 **B020**: Loop control variable overrides iterable it iterates
 
+**B021**: f-string used as docstring. This will be interpreted by python
+as a joined string rather than a docstring.
+
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -695,7 +695,7 @@ class BugBearVisitor(ast.NodeVisitor):
             and ast.get_source_segment(
                 "".join(self.lines),
                 node.body[0].value,
-            ).startswith('f"""')
+            ).startswith(('f"', "f'"))
         ):
             self.errors.append(
                 B021(node.body[0].value.lineno, node.body[0].value.col_offset)

--- a/bugbear.py
+++ b/bugbear.py
@@ -692,10 +692,6 @@ class BugBearVisitor(ast.NodeVisitor):
             node.body
             and isinstance(node.body[0], ast.Expr)
             and isinstance(node.body[0].value, ast.JoinedStr)
-            and ast.get_source_segment(
-                "".join(self.lines),
-                node.body[0].value,
-            ).startswith(('f"', "f'"))
         ):
             self.errors.append(
                 B021(node.body[0].value.lineno, node.body[0].value.col_offset)

--- a/bugbear.py
+++ b/bugbear.py
@@ -350,11 +350,13 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b902(node)
         self.check_for_b006(node)
         self.check_for_b018(node)
+        self.check_for_b021(node)
         self.generic_visit(node)
 
     def visit_ClassDef(self, node):
         self.check_for_b903(node)
         self.check_for_b018(node)
+        self.check_for_b021(node)
         self.generic_visit(node)
 
     def visit_Try(self, node):
@@ -685,6 +687,20 @@ class BugBearVisitor(ast.NodeVisitor):
             ):
                 self.errors.append(B018(subnode.lineno, subnode.col_offset))
 
+    def check_for_b021(self, node):
+        if (
+            node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.JoinedStr)
+            and ast.get_source_segment(
+                "".join(self.lines),
+                node.body[0].value,
+            ).startswith('f"""')
+        ):
+            self.errors.append(
+                B021(node.body[0].value.lineno, node.body[0].value.col_offset)
+            )
+
 
 @attr.s
 class NameFinder(ast.NodeVisitor):
@@ -890,6 +906,12 @@ B020 = Error(
     message=(
         "B020 Found for loop that reassigns the iterable it is iterating "
         + "with each iterable value."
+    )
+)
+B021 = Error(
+    message=(
+        "B021 f-string used as docstring."
+        "This will be interpreted by python as a joined string rather than a docstring."
     )
 )
 

--- a/tests/b021.py
+++ b/tests/b021.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B021 - on lines 14, 22
+B021 - on lines 14, 22, 30, 38, 46, 54, 62, 70, 73
 """
 
 VARIABLE = "world"
@@ -20,3 +20,57 @@ class bar1:
 
 class bar2:
     f"""hello {VARIABLE}!"""
+
+
+def foo1():
+    """hello world!"""
+
+
+def foo2():
+    f"""hello {VARIABLE}!"""
+
+
+class bar1:
+    """hello world!"""
+
+
+class bar2:
+    f"""hello {VARIABLE}!"""
+
+
+def foo1():
+    "hello world!"
+
+
+def foo2():
+    f"hello {VARIABLE}!"
+
+
+class bar1:
+    "hello world!"
+
+
+class bar2:
+    f"hello {VARIABLE}!"
+
+
+def foo1():
+    "hello world!"
+
+
+def foo2():
+    f"hello {VARIABLE}!"
+
+
+class bar1:
+    "hello world!"
+
+
+class bar2:
+    f"hello {VARIABLE}!"
+
+
+def baz():
+    f"""I'm probably a docstring: {VARIABLE}!"""
+    print(f"""I'm a normal string""")
+    f"""Don't detect me!"""

--- a/tests/b021.py
+++ b/tests/b021.py
@@ -1,0 +1,22 @@
+"""
+Should emit:
+B021 - on lines 14, 22
+"""
+
+VARIABLE = "world"
+
+
+def foo1():
+    """hello world!"""
+
+
+def foo2():
+    f"""hello {VARIABLE}!"""
+
+
+class bar1:
+    """hello world!"""
+
+
+class bar2:
+    f"""hello {VARIABLE}!"""

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -30,6 +30,7 @@ from bugbear import (
     B017,
     B018,
     B020,
+    B021,
     B901,
     B902,
     B903,
@@ -261,6 +262,13 @@ class BugbearTestCase(unittest.TestCase):
                 B020(21, 9, vars=("values",)),
             ),
         )
+
+    def test_b021_classes(self):
+        filename = Path(__file__).absolute().parent / "b021.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(B021(14, 4), B021(22, 4))
+        self.assertEqual(errors, expected)
 
     def test_b901(self):
         filename = Path(__file__).absolute().parent / "b901.py"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -267,7 +267,17 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b021.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B021(14, 4), B021(22, 4))
+        expected = self.errors(
+            B021(14, 4),
+            B021(22, 4),
+            B021(30, 4),
+            B021(38, 4),
+            B021(46, 4),
+            B021(54, 4),
+            B021(62, 4),
+            B021(70, 4),
+            B021(74, 4),
+        )
         self.assertEqual(errors, expected)
 
     def test_b901(self):


### PR DESCRIPTION
Closes #211.

The logic for detecting these f-strings intended as docstrings is fairly simple: Check that the first child of the `FunctionDef`/`ClassDef` is a `JoinedStr`.

I've added a working unit test and ran the pre-commit checks but since this is my first contribution here lmk if I've missed anything 😄 