### PR TITLE
B022: No arguments passed to contextlib.suppress

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ data available in ``ex``.
 
 **B020**: Loop control variable overrides iterable it iterates
 
-**B022**: B022 No arguments passed to `contextlib.suppress`.
+**B022**: No arguments passed to `contextlib.suppress`.
 No exceptions will be suppressed and therefore this context manager is redundant.
 
 

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,9 @@ data available in ``ex``.
 
 **B020**: Loop control variable overrides iterable it iterates
 
+**B022**: B022 No arguments passed to `contextlib.suppress`.
+No exceptions will be suppressed and therefore this context manager is redundant.
+
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,8 @@ as a joined string rather than a docstring.
 
 **B022**: No arguments passed to `contextlib.suppress`.
 No exceptions will be suppressed and therefore this context manager is redundant.
+N.B. this rule currently does not flag `suppress` calls to avoid potential false
+positives due to similarly named user-defined functions.
 
 
 Opinionated warnings

--- a/bugbear.py
+++ b/bugbear.py
@@ -372,6 +372,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
     def visit_With(self, node):
         self.check_for_b017(node)
+        self.check_for_b022(node)
         self.generic_visit(node)
 
     def compose_call_path(self, node):
@@ -685,6 +686,20 @@ class BugBearVisitor(ast.NodeVisitor):
             ):
                 self.errors.append(B018(subnode.lineno, subnode.col_offset))
 
+    def check_for_b022(self, node):
+        item = node.items[0]
+        item_context = item.context_expr
+        if (
+            hasattr(item_context, "func")
+            and hasattr(item_context.func, "value")
+            and hasattr(item_context.func.value, "id")
+            and item_context.func.value.id == "contextlib"
+            and hasattr(item_context.func, "attr")
+            and item_context.func.attr == "suppress"
+            and len(item_context.args) == 0
+        ):
+            self.errors.append(B022(node.lineno, node.col_offset))
+
 
 @attr.s
 class NameFinder(ast.NodeVisitor):
@@ -890,6 +905,13 @@ B020 = Error(
     message=(
         "B020 Found for loop that reassigns the iterable it is iterating "
         + "with each iterable value."
+    )
+)
+B022 = Error(
+    message=(
+        "B022 No arguments passed to `contextlib.suppress`."
+        "No exceptions will be suppressed and therefore this"
+        "context manager is redundant."
     )
 )
 

--- a/tests/b022.py
+++ b/tests/b022.py
@@ -1,0 +1,19 @@
+"""
+Should emit:
+B022 - on lines 8
+"""
+
+import contextlib
+
+with contextlib.suppress():
+    raise ValueError
+
+with contextlib.suppress(ValueError):
+    raise ValueError
+
+exceptions_to_suppress = []
+if True:
+    exceptions_to_suppress.append(ValueError)
+
+with contextlib.suppress(*exceptions_to_suppress):
+    raise ValueError

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -280,7 +280,7 @@ class BugbearTestCase(unittest.TestCase):
             B021(74, 4),
         )
         self.assertEqual(errors, expected)
-        
+
     def test_b022(self):
         filename = Path(__file__).absolute().parent / "b022.py"
         bbc = BugBearChecker(filename=str(filename))

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -30,6 +30,7 @@ from bugbear import (
     B017,
     B018,
     B020,
+    B022,
     B901,
     B902,
     B903,
@@ -261,6 +262,12 @@ class BugbearTestCase(unittest.TestCase):
                 B020(21, 9, vars=("values",)),
             ),
         )
+
+    def test_b022(self):
+        filename = Path(__file__).absolute().parent / "b022.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(errors, self.errors(B022(8, 0)))
 
     def test_b901(self):
         filename = Path(__file__).absolute().parent / "b901.py"


### PR DESCRIPTION
Closes #222. 

This covers the case where `contextlib.suppress` is used
```
import contextlib

with contextlib.suppress():  
    raise ValueError
```


However, it does not currently cover the case where `suppress` is imported from `contextlib`
```
from contextlib import suppress

with suppress():  
    raise ValueError
```
Do you know of any existing flake8 helper functions/methods to tie the `suppress` function node to it's import? 
I don't want to just ignore the one word `suppress` without checking incase it's actually a user defined function.