### PR TITLE
Clarify B019 description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ data available in ``ex``.
 
 **B018**: Found useless expression. Either assign it to a variable or remove it.
 
-**B019**: Use of ``functools.lru_cache`` or ``functools.cache`` on class methods
+**B019**: Use of ``functools.lru_cache`` or ``functools.cache`` on methods
 can lead to memory leaks. The cache may retain instance references, preventing
 garbage collection.
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -957,7 +957,7 @@ B018 = Error(
 )
 B019 = Error(
     message=(
-        "B019 Use of `functools.lru_cache` or `functools.cache` on class methods "
+        "B019 Use of `functools.lru_cache` or `functools.cache` on methods "
         "can lead to memory leaks. The cache may retain instance references, "
         "preventing garbage collection."
     )


### PR DESCRIPTION
Closes #236.
The previous description warned about using lru_cache on `class methods` which is redundant as `methods` belong to a class by definition and leads to confusion with `classmethods` (i.e. methods decorated with `@classmethod`).
﻿
