### PR TITLE
B020: Fix comprehension false postives

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -557,7 +557,7 @@ class BugBearVisitor(ast.NodeVisitor):
         targets.visit(node.target)
         ctrl_names = set(targets.names)
 
-        iterset = NameFinder()
+        iterset = B020NameFinder()
         iterset.visit(node.iter)
         iterset_names = set(iterset.names)
 
@@ -776,6 +776,22 @@ class NameFinder(ast.NodeVisitor):
         for elem in node:
             super().visit(elem)
         return node
+
+
+class B020NameFinder(NameFinder):
+    """Ignore names defined within the local scope of a comprehension."""
+
+    def visit_GeneratorExp(self, node):
+        self.visit(node.generators)
+
+    def visit_ListComp(self, node):
+        self.visit(node.generators)
+
+    def visit_DictComp(self, node):
+        self.visit(node.generators)
+
+    def visit_comprehension(self, node):
+        self.visit(node.iter)
 
 
 error = namedtuple("error", "lineno col message type vars")

--- a/tests/b020.py
+++ b/tests/b020.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B020 - on lines 8 and 21
+B020 - on lines 8, 21, and 36
 """
 
 items = [1, 2, 3]
@@ -20,3 +20,18 @@ for key, value in values.items():
 
 for key, values in values.items():
     print(f"{key}, {values}")
+
+# Variables defined in a comprehension are local in scope
+# to that comprehension and are therefore allowed.
+for var in [var for var in range(10)]:
+    print(var)
+
+for var in (var for var in range(10)):
+    print(var)
+
+for k, v in {k: v for k, v in zip(range(10), range(10, 20))}.items():
+    print(k, v)
+
+# However we still call out reassigning the iterable in the comprehension.
+for vars in [i for i in vars]:
+    print(vars)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -284,6 +284,7 @@ class BugbearTestCase(unittest.TestCase):
             self.errors(
                 B020(8, 4, vars=("items",)),
                 B020(21, 9, vars=("values",)),
+                B020(36, 4, vars=("vars",)),
             ),
         )
 


### PR DESCRIPTION
Closes #235.

Fixes a false positive for B020 where a variable defined in a comprehension is reused in the `for` loop targets.