### PR TITLE
Fix B008 edge case with lambda functions

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -791,6 +791,11 @@ class FuntionDefDefaultsVisitor(ast.NodeVisitor):
         # Check for nested functions.
         self.generic_visit(node)
 
+    def visit_Lambda(self, node):
+        # Don't recurse into lambda expressions
+        # as they are evaluated at call time.
+        pass
+
     def visit(self, node):
         """Like super-visit but supports iteration over lists."""
         self.arg_depth += 1

--- a/tests/b006_b008.py
+++ b/tests/b006_b008.py
@@ -180,3 +180,8 @@ def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
 # B008-ception.
 def nested_b008(a=random.randint(0, dt.datetime.now().year)):
     pass
+
+
+# Ignore lambda contents since they are evaluated at call time.
+def foo(f=lambda x: print(x)):
+    f(1)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -124,7 +124,6 @@ class BugbearTestCase(unittest.TestCase):
                 B008(170, 20),
                 B008(170, 30),
                 B008(176, 21),
-                B008(176, 35),
                 B008(181, 18),
                 B008(181, 36),
             ),


### PR DESCRIPTION
Closes #242

In #239 I introduced the ability to detect functions at any depth of function default args to prevent things like:
```python
def foo(a=[datetime.now()], b=bar(datetime.now())): ...
```

One thing I overlooked was lambda functions which are slightly different given that their contents act as function body and are therefore only evaluated when the lambda function is called, therefore B008 doesn't apply to these.
```python
from datetime import datetime
import time

def foo(f=lambda x: datetime.now()):
    print(f(1))
    time.sleep(5)
    print(f(1))

foo()
```
prints
```
2022-03-25 11:36:22.999143
2022-03-25 11:36:28.004194
```

Fix is pretty simple, don't check inside lambda functions.
