### PR TITLE
Black: replace `--experimental-string-processing` with `--preview`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,4 @@ repos:
     hooks:
       - id: black
         args:
-        - --experimental-string-processing
+        - --preview


### PR DESCRIPTION
As part of #239 we updated black version. In the new black version the `--experimental-string-processing` flag has been moved into the `--preview` flag
```
Deprecated: `experimental string processing` has been included in `preview` and deprecated. Use `preview` instead.
```

We can either use the `--preview` flag (has a couple extra new features as well) or just not use any flags. I'd prefer to use the `--preview` flag as we can help improve the newer black features, but easy either way 😄 