### PR TITLE
don't crash when select / extend_select are None

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -155,12 +155,13 @@ class BugBearChecker:
             return True
 
         for i in range(2, len(code) + 1):
-            if code[:i] in self.options.select:
+            if self.options.select and code[:i] in self.options.select:
                 return True
 
             # flake8 >=4.0: Also check for codes in extend_select
             if (
                 hasattr(self.options, "extend_select")
+                and self.options.extend_select
                 and code[:i] in self.options.extend_select
             ):
                 return True

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -438,6 +438,16 @@ class BugbearTestCase(unittest.TestCase):
             ),
         )
 
+    def test_b9_flake8_next_default_options(self):
+        filename = Path(__file__).absolute().parent / "b950.py"
+
+        # in flake8 next, unset select / extend_select will be `None` to
+        # signify the default values
+        mock_options = Namespace(select=None, extend_select=None)
+        bbc = BugBearChecker(filename=str(filename), options=mock_options)
+        errors = list(bbc.run())
+        self.assertEqual(errors, [])
+
     def test_selfclean_bugbear(self):
         filename = Path(__file__).absolute().parent.parent / "bugbear.py"
         proc = subprocess.run(


### PR DESCRIPTION
resolves #260

this is the minimal fix -- rather than removing the (I believe unneeded) methods I'll let you decide when you want to remove support for old flake8 versions