### PR TITLE
Add B027: empty method in abstract base class with no abstract decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,23 +296,21 @@ MIT
 
 Change Log
 ----------
+Future
+~~~~~~~~~
 
-<<<<<<< HEAD
+* Add B027: Empty method in abstract base class with no abstract decorator
+
 22.9.23
 ~~~~~~~~~~
 
-* add B026: find argument unpacking after keyword argument (#287)
+* Add B026: find argument unpacking after keyword argument (#287)
 * Move to setup.cfg like flake8 (#288)
 
 22.9.11
 ~~~~~~~~~~
 
-* add B025: find duplicate except clauses (#284)
-=======
-Future
-~~~~~~~~~
-* Add B025: Empty method in abstract base class with no abstract decorator.
->>>>>>> 0937a2d (Adding B025: empty method in abstract base class with no abstract decorator)
+* Add B025: find duplicate except clauses (#284)
 
 22.8.23
 ~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ positives due to similarly named user-defined functions.
 the loop, because `late-binding closures are a classic gotcha
 <https://docs.python-guide.org/writing/gotchas/#late-binding-closures>`__.
 
-**B024**: Abstract base class with no abstract method. Remember to use @abstractmethod, @abstractclassmethod, and/or @abstractproperty decorators.
+**B024**: Abstract base class with no abstract method. You might have forgotten to add @abstractmethod.
 
 **B025**: ``try-except`` block with duplicate exceptions found.
 This check identifies exception types that are specified in multiple ``except``
@@ -166,6 +166,8 @@ the unpacked sequence, and this change of ordering can surprise and mislead read
 There was `cpython discussion of disallowing this syntax
 <https://github.com/python/cpython/issues/82741>`_, but legacy usage and parser
 limitations make it difficult.
+
+**B027**: Empty method in abstract base class, but has no abstract decorator. Consider adding @abstractmethod.
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
@@ -295,6 +297,7 @@ MIT
 Change Log
 ----------
 
+<<<<<<< HEAD
 22.9.23
 ~~~~~~~~~~
 
@@ -305,6 +308,11 @@ Change Log
 ~~~~~~~~~~
 
 * add B025: find duplicate except clauses (#284)
+=======
+Future
+~~~~~~~~~
+* Add B025: Empty method in abstract base class with no abstract decorator.
+>>>>>>> 0937a2d (Adding B025: empty method in abstract base class with no abstract decorator)
 
 22.8.23
 ~~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -612,7 +612,7 @@ class BugBearVisitor(ast.NodeVisitor):
             if reassigned_in_loop.issuperset(err.vars):
                 self.errors.append(err)
 
-    def check_for_b024_and_b027(self, node: ast.ClassDef):
+    def check_for_b024_and_b027(self, node: ast.ClassDef):  # noqa: C901
         """Check for inheritance from abstract classes in abc and lack of
         any methods decorated with abstract*"""
 
@@ -661,6 +661,12 @@ class BugBearVisitor(ast.NodeVisitor):
         has_abstract_method = False
 
         for stmt in node.body:
+            # https://github.com/PyCQA/flake8-bugbear/issues/293
+            # Ignore abc's that declares a class attribute that must be set
+            if isinstance(stmt, (ast.AnnAssign, ast.Assign)):
+                has_abstract_method = True
+                continue
+
             # only check function defs
             if not isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue

--- a/bugbear.py
+++ b/bugbear.py
@@ -635,17 +635,17 @@ class BugBearVisitor(ast.NodeVisitor):
             )
 
         def empty_body(body) -> bool:
+            def is_str_or_ellipsis(node):
+                # ast.Ellipsis and ast.Str used in python<3.8
+                return isinstance(node, (ast.Ellipsis, ast.Str)) or (
+                    isinstance(node, ast.Constant)
+                    and (node.value is Ellipsis or isinstance(node.value, str))
+                )
+
             # Function body consist solely of `pass`, `...`, and/or (doc)string literals
             return all(
                 isinstance(stmt, ast.Pass)
-                or (
-                    isinstance(stmt, ast.Expr)
-                    and isinstance(stmt.value, ast.Constant)
-                    and (
-                        stmt.value.value is Ellipsis
-                        or isinstance(stmt.value.value, str)
-                    )
-                )
+                or (isinstance(stmt, ast.Expr) and is_str_or_ellipsis(stmt.value))
                 for stmt in body
             )
 

--- a/tests/b024.py
+++ b/tests/b024.py
@@ -110,3 +110,20 @@ class keyword_abc_1(metaclass=ABC):  # safe
 class keyword_abc_2(metaclass=abc.ABC):  # safe
     def method(self):
         foo()
+
+
+class abc_set_class_variable_1(ABC):  # safe
+    foo: int
+
+
+class abc_set_class_variable_2(ABC):  # safe
+    foo = 2
+
+
+class abc_set_class_variable_3(ABC):  # safe
+    foo: int = 2
+
+
+# this doesn't actually declare a class variable, it's just an expression
+class abc_set_class_variable_4(ABC):  # error
+    foo

--- a/tests/b024.py
+++ b/tests/b024.py
@@ -81,11 +81,32 @@ class notabc_Base_1(notabc.ABC):  # safe
         foo()
 
 
-class multi_super_1(notabc.ABC, abc.ABCMeta):  # error
+class multi_super_1(notabc.ABC, abc.ABCMeta):  # safe
     def method(self):
         foo()
 
 
-class multi_super_2(notabc.ABC, metaclass=abc.ABCMeta):  # error
+class multi_super_2(notabc.ABC, metaclass=abc.ABCMeta):  # safe
+    def method(self):
+        foo()
+
+
+class non_keyword_abcmeta_1(ABCMeta):  # safe
+    def method(self):
+        foo()
+
+
+class non_keyword_abcmeta_2(abc.ABCMeta):  # safe
+    def method(self):
+        foo()
+
+
+# very invalid code, but that's up to mypy et al to check
+class keyword_abc_1(metaclass=ABC):  # safe
+    def method(self):
+        foo()
+
+
+class keyword_abc_2(metaclass=abc.ABC):  # safe
     def method(self):
         foo()

--- a/tests/b024.py
+++ b/tests/b024.py
@@ -16,76 +16,76 @@ B024 - on lines 17, 34, 52, 58, 69, 74, 84, 89
 
 class Base_1(ABC):  # error
     def method(self):
-        ...
+        foo()
 
 
 class Base_2(ABC):
     @abstractmethod
     def method(self):
-        ...
+        foo()
 
 
 class Base_3(ABC):
     @abc.abstractmethod
     def method(self):
-        ...
+        foo()
 
 
 class Base_4(ABC):
     @notabc.abstractmethod
     def method(self):
-        ...
+        foo()
 
 
 class Base_5(ABC):
     @abstract
     def method(self):
-        ...
+        foo()
 
 
 class Base_6(ABC):
     @abstractaoeuaoeuaoeu
     def method(self):
-        ...
+        foo()
 
 
 class Base_7(ABC):  # error
     @notabstract
     def method(self):
-        ...
+        foo()
 
 
 class MetaBase_1(metaclass=ABCMeta):  # error
     def method(self):
-        ...
+        foo()
 
 
 class MetaBase_2(metaclass=ABCMeta):
     @abstractmethod
     def method(self):
-        ...
+        foo()
 
 
 class abc_Base_1(abc.ABC):  # error
     def method(self):
-        ...
+        foo()
 
 
 class abc_Base_2(metaclass=abc.ABCMeta):  # error
     def method(self):
-        ...
+        foo()
 
 
 class notabc_Base_1(notabc.ABC):  # safe
     def method(self):
-        ...
+        foo()
 
 
 class multi_super_1(notabc.ABC, abc.ABCMeta):  # error
     def method(self):
-        ...
+        foo()
 
 
 class multi_super_2(notabc.ABC, metaclass=abc.ABCMeta):  # error
     def method(self):
-        ...
+        foo()

--- a/tests/b027.py
+++ b/tests/b027.py
@@ -1,0 +1,59 @@
+import abc
+from abc import ABC
+from abc import abstractmethod
+from abc import abstractmethod as notabstract
+
+"""
+Should emit:
+B025 - on lines 13, 16, 19, 23, 31
+"""
+
+
+class AbstractClass(ABC):
+    def empty_1(self):  # error
+        ...
+
+    def empty_2(self):  # error
+        pass
+
+    def empty_3(self):  # error
+        """docstring"""
+        ...
+
+    def empty_4(self):  # error
+        """multiple ellipsis/pass"""
+        ...
+        pass
+        ...
+        pass
+
+    @notabstract
+    def empty_5(self):  # error
+        ...
+
+    @abstractmethod
+    def abstract_1(self):
+        ...
+
+    @abstractmethod
+    def abstract_2(self):
+        pass
+
+    @abc.abstractmethod
+    def abstract_3(self):
+        ...
+
+    def body_1(self):
+        print("foo")
+        ...
+
+    def body_2(self):
+        self.body_1()
+
+
+class NonAbstractClass:
+    def empty_1(self):  # safe
+        ...
+
+    def empty_2(self):  # safe
+        pass

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -37,6 +37,7 @@ from bugbear import (
     B024,
     B025,
     B026,
+    B027,
     B901,
     B902,
     B903,
@@ -398,6 +399,19 @@ class BugbearTestCase(unittest.TestCase):
                 B026(21, 25),
             ),
         )
+
+    def test_b027(self):
+        filename = Path(__file__).absolute().parent / "b025.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B025(13, 4, vars=("empty_1",)),
+            B025(16, 4, vars=("empty_2",)),
+            B025(19, 4, vars=("empty_3",)),
+            B025(23, 4, vars=("empty_4",)),
+            B025(31, 4, vars=("empty_5",)),
+        )
+        self.assertEqual(errors, expected)
 
     def test_b901(self):
         filename = Path(__file__).absolute().parent / "b901.py"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -364,8 +364,6 @@ class BugbearTestCase(unittest.TestCase):
             B024(58, 0, vars=("MetaBase_1",)),
             B024(69, 0, vars=("abc_Base_1",)),
             B024(74, 0, vars=("abc_Base_2",)),
-            B024(84, 0, vars=("multi_super_1",)),
-            B024(89, 0, vars=("multi_super_2",)),
         )
         self.assertEqual(errors, expected)
 
@@ -401,15 +399,15 @@ class BugbearTestCase(unittest.TestCase):
         )
 
     def test_b027(self):
-        filename = Path(__file__).absolute().parent / "b025.py"
+        filename = Path(__file__).absolute().parent / "b027.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B025(13, 4, vars=("empty_1",)),
-            B025(16, 4, vars=("empty_2",)),
-            B025(19, 4, vars=("empty_3",)),
-            B025(23, 4, vars=("empty_4",)),
-            B025(31, 4, vars=("empty_5",)),
+            B027(13, 4, vars=("empty_1",)),
+            B027(16, 4, vars=("empty_2",)),
+            B027(19, 4, vars=("empty_3",)),
+            B027(23, 4, vars=("empty_4",)),
+            B027(31, 4, vars=("empty_5",)),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -407,7 +407,7 @@ class BugbearTestCase(unittest.TestCase):
             B027(16, 4, vars=("empty_2",)),
             B027(19, 4, vars=("empty_3",)),
             B027(23, 4, vars=("empty_4",)),
-            B027(31, 4, vars=("empty_5",)),
+            B027(31 if sys.version_info >= (3, 8) else 30, 4, vars=("empty_5",)),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -364,6 +364,7 @@ class BugbearTestCase(unittest.TestCase):
             B024(58, 0, vars=("MetaBase_1",)),
             B024(69, 0, vars=("abc_Base_1",)),
             B024(74, 0, vars=("abc_Base_2",)),
+            B024(128, 0, vars=("abc_set_class_variable_4",)),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
EDIT: I read through the issues and realized that B024 needs changes, so made this a draft for now.

Implements the second suggested check in #273 

There seems to be some difference in style on ellipsis vs pass, so one might want to restrict the check to only be if the body is docstring and ellipsis.

When reading the docs on abc I also found out that the abstract decorators inside it other than `@abstractmethod` are [deprecated](https://docs.python.org/3/library/abc.html?highlight=abc#abc.abstractclassmethod) so I modified the b024 message to not suggest deprecated decorators.
Modified the b024 test to not trigger b027

Fixes #277, fixes #278 (though see #290), and fixes #280.