### PR TITLE
Migrate metadata from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,57 @@
+[metadata]
+license_file = LICENSE
+name = flake8-bugbear
+version = attr: bugbear.__version__
+author = Łukasz Langa
+author_email = lukasz@langa.pl
+license = MIT
+description = A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle.
+keywords =
+    flake8
+    bugbear
+    bugs
+    pyflakes
+    pylint
+    linter
+    qa
+url = https://github.com/PyCQA/flake8-bugbear
+long_description = file: README.rst
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Framework :: Flake8
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3 :: Only
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Software Development :: Quality Assurance
+project_urls =
+    Change Log = https://github.com/PyCQA/flake8-bugbear#change-log
+
+[options]
+py_modules = bugbear
+zip_safe = False
+install_requires = flake8 >= 3.0.0; attrs>=19.2.0
+python_requires = >=3.6
+test_suite = tests.test_bugbear
+
+[options.entry_points]
+flake8.extension = B = bugbear:BugBearChecker
+
+[options.extras_require]
+dev =
+    coverage
+    hypothesis
+    hypothesmith>=0.2
+    pre-commit
+
 [flake8]
 # Keep in sync with .flake8. This copy here is needed for source packages
 # to be able to pass tests without failing selfclean check.
@@ -5,6 +59,3 @@ ignore = E203, E302, E501, E999, W503
 max-line-length = 88
 max-complexity = 12
 select = B,C,E,F,W,B9
-
-[metadata]
-license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,4 @@
 
 from setuptools import setup
 
-
 setup()

--- a/setup.py
+++ b/setup.py
@@ -1,67 +1,6 @@
 # Copyright (C) 2016-2021 Łukasz Langa
 
-import ast
-import os
-import re
-import sys
-
 from setuptools import setup
 
-assert sys.version_info >= (3, 6, 0), "bugbear requires Python 3.6+"
 
-
-current_dir = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(current_dir, "README.rst"), encoding="utf8") as ld_file:
-    long_description = ld_file.read()
-
-
-_version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
-
-
-with open(os.path.join(current_dir, "bugbear.py"), "r") as f:
-    version = _version_re.search(f.read()).group("version")
-    version = str(ast.literal_eval(version))
-
-
-setup(
-    name="flake8-bugbear",
-    version=version,
-    description=(
-        "A plugin for flake8 finding likely bugs and design problems "
-        "in your program. Contains warnings that don't belong in "
-        "pyflakes and pycodestyle."
-    ),
-    long_description=long_description,
-    keywords="flake8 bugbear bugs pyflakes pylint linter qa",
-    author="Łukasz Langa",
-    author_email="lukasz@langa.pl",
-    url="https://github.com/PyCQA/flake8-bugbear",
-    license="MIT",
-    py_modules=["bugbear"],
-    zip_safe=False,
-    python_requires=">=3.6",
-    install_requires=["flake8 >= 3.0.0", "attrs>=19.2.0"],
-    test_suite="tests.test_bugbear",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Framework :: Flake8",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3 :: Only",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Software Development :: Quality Assurance",
-    ],
-    entry_points={"flake8.extension": ["B = bugbear:BugBearChecker"]},
-    extras_require={
-        "dev": ["coverage", "hypothesis", "hypothesmith>=0.2", "pre-commit"]
-    },
-    project_urls={"Change Log": "https://github.com/PyCQA/flake8-bugbear#change-log"},
-)
+setup()


### PR DESCRIPTION
This pull request was created using https://pypi.org/project/setuptools-py2cfg plus manual modifications.

https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use
> We recommend users expose as much as possible configuration in a more declarative way via the [pyproject.toml](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) or [setup.cfg](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html), and keep the setup.py minimal with only the dynamic parts (or even omit it completely if applicable).