### PR TITLE
Fix some B023 false alarms

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -280,7 +280,7 @@ class BugBearVisitor(ast.NodeVisitor):
             names = [_to_name_str(e) for e in node.type.elts]
             as_ = " as " + node.name if node.name is not None else ""
             if len(names) == 0:
-                vs = ("`except (){}:`".format(as_),)
+                vs = (f"`except (){as_}:`",)
                 self.errors.append(B001(node.lineno, node.col_offset, vars=vs))
             elif len(names) == 1:
                 self.errors.append(B013(node.lineno, node.col_offset, vars=names))
@@ -912,7 +912,7 @@ class BugBearVisitor(ast.NodeVisitor):
                     uniques.add(name)
                 seen.extend(uniques)
         # sort to have a deterministic output
-        duplicates = sorted(set(x for x in seen if seen.count(x) > 1))
+        duplicates = sorted({x for x in seen if seen.count(x) > 1})
         for duplicate in duplicates:
             self.errors.append(B025(node.lineno, node.col_offset, vars=(duplicate,)))
 

--- a/tests/b023.py
+++ b/tests/b023.py
@@ -115,3 +115,33 @@ for x in range(2):
     any(filter(bool, [None, lambda: x]))
     list(filter(bool, [None, lambda: x]))
     all(reduce(bool, [None, lambda: x]))
+
+    # But all these ones should be OK:
+    min(range(3), key=lambda y: x * y)
+    max(range(3), key=lambda y: x * y)
+    sorted(range(3), key=lambda y: x * y)
+
+    any(filter(lambda y: x < y, range(3)))
+    all(filter(lambda y: x < y, range(3)))
+    set(filter(lambda y: x < y, range(3)))
+    list(filter(lambda y: x < y, range(3)))
+    tuple(filter(lambda y: x < y, range(3)))
+    sorted(filter(lambda y: x < y, range(3)))
+    frozenset(filter(lambda y: x < y, range(3)))
+
+    any(reduce(lambda y: x | y, range(3)))
+    all(reduce(lambda y: x | y, range(3)))
+    set(reduce(lambda y: x | y, range(3)))
+    list(reduce(lambda y: x | y, range(3)))
+    tuple(reduce(lambda y: x | y, range(3)))
+    sorted(reduce(lambda y: x | y, range(3)))
+    frozenset(reduce(lambda y: x | y, range(3)))
+
+
+# OK because the lambda which references a loop variable is defined in a `return`
+# statement, and after we return the loop variable can't be redefined.
+# In principle we could do something fancy with `break`, but it's not worth it.
+def iter_f(names):
+    for name in names:
+        if exists(name):
+            return lambda: name if exists(name) else None

--- a/tests/b023.py
+++ b/tests/b023.py
@@ -76,3 +76,31 @@ for var in range(2):
 
     def explicit_capture(captured=var):
         return captured
+
+
+# `query` is defined in the function, so also defining it in the loop should be OK.
+for name in ["a", "b"]:
+    query = name
+
+    def myfunc(x):
+        query = x
+        query_post = x
+        _ = query
+        _ = query_post
+
+    query_post = name  # in case iteration order matters
+
+
+# Bug here because two dict comprehensions reference `name`, one of which is inside
+# the lambda.  This should be totally fine, of course.
+_ = {
+    k: v
+    for k, v in reduce(
+        lambda data, event: merge_mappings(
+            [data, {name: f(caches, data, event) for name, f in xx}]
+        ),
+        events,
+        {name: getattr(group, name) for name in yy},
+    ).items()
+    if k in backfill_fields
+}

--- a/tests/b023.py
+++ b/tests/b023.py
@@ -2,10 +2,10 @@
 Should emit:
 B023 - on lines 12, 13, 16, 28, 29, 30, 31, 40, 42, 50, 51, 52, 53, 61, 68.
 """
+from functools import reduce
 
 functions = []
 z = 0
-
 for x in range(3):
     y = x + 1
     # Subject to late-binding problems
@@ -104,3 +104,14 @@ _ = {
     ).items()
     if k in backfill_fields
 }
+
+
+# OK to define lambdas if they're immediately consumed, typically as the `key=`
+# argument or in a consumed `filter()` (even if a comprehension is better style)
+for x in range(2):
+    # It's not a complete get-out-of-linting-free construct - these should fail:
+    min([None, lambda: x], key=repr)
+    sorted([None, lambda: x], key=repr)
+    any(filter(bool, [None, lambda: x]))
+    list(filter(bool, [None, lambda: x]))
+    all(reduce(bool, [None, lambda: x]))

--- a/tests/b023.py
+++ b/tests/b023.py
@@ -25,10 +25,10 @@ for x in range(3):
 
 
 def check_inside_functions_too():
-    ls = [lambda: x for x in range(2)]
-    st = {lambda: x for x in range(2)}
-    gn = (lambda: x for x in range(2))
-    dt = {x: lambda: x for x in range(2)}
+    ls = [lambda: x for x in range(2)]  # error
+    st = {lambda: x for x in range(2)}  # error
+    gn = (lambda: x for x in range(2))  # error
+    dt = {x: lambda: x for x in range(2)}  # error
 
 
 async def pointless_async_iterable():
@@ -37,9 +37,9 @@ async def pointless_async_iterable():
 
 async def container_for_problems():
     async for x in pointless_async_iterable():
-        functions.append(lambda: x)
+        functions.append(lambda: x)  # error
 
-    [lambda: x async for x in pointless_async_iterable()]
+    [lambda: x async for x in pointless_async_iterable()]  # error
 
 
 a = 10
@@ -47,10 +47,10 @@ b = 0
 while True:
     a = a_ = a - 1
     b += 1
-    functions.append(lambda: a)
-    functions.append(lambda: a_)
-    functions.append(lambda: b)
-    functions.append(lambda: c)  # not a name error because of late binding!
+    functions.append(lambda: a)  # error
+    functions.append(lambda: a_)  # error
+    functions.append(lambda: b)  # error
+    functions.append(lambda: c)  # error, but not a name error due to late binding
     c: bool = a > 3
     if not c:
         break
@@ -58,7 +58,7 @@ while True:
 # Nested loops should not duplicate reports
 for j in range(2):
     for k in range(3):
-        lambda: j * k
+        lambda: j * k  # error
 
 
 for j, k, l in [(1, 2, 3)]:
@@ -137,6 +137,15 @@ for x in range(2):
     sorted(reduce(lambda y: x | y, range(3)))
     frozenset(reduce(lambda y: x | y, range(3)))
 
+    import functools
+
+    any(functools.reduce(lambda y: x | y, range(3)))
+    all(functools.reduce(lambda y: x | y, range(3)))
+    set(functools.reduce(lambda y: x | y, range(3)))
+    list(functools.reduce(lambda y: x | y, range(3)))
+    tuple(functools.reduce(lambda y: x | y, range(3)))
+    sorted(functools.reduce(lambda y: x | y, range(3)))
+    frozenset(functools.reduce(lambda y: x | y, range(3)))
 
 # OK because the lambda which references a loop variable is defined in a `return`
 # statement, and after we return the loop variable can't be redefined.
@@ -145,3 +154,9 @@ def iter_f(names):
     for name in names:
         if exists(name):
             return lambda: name if exists(name) else None
+
+        if foo(name):
+            return [lambda: name]  # false alarm, should be fixed?
+
+        if False:
+            return [lambda: i for i in range(3)]  # error

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -351,6 +351,11 @@ class BugbearTestCase(unittest.TestCase):
             B023(61, 16, vars=("j",)),
             B023(61, 20, vars=("k",)),
             B023(68, 9, vars=("l",)),
+            B023(113, 23, vars=("x",)),
+            B023(114, 26, vars=("x",)),
+            B023(115, 36, vars=("x",)),
+            B023(116, 37, vars=("x",)),
+            B023(117, 36, vars=("x",)),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -356,6 +356,8 @@ class BugbearTestCase(unittest.TestCase):
             B023(115, 36, vars=("x",)),
             B023(116, 37, vars=("x",)),
             B023(117, 36, vars=("x",)),
+            B023(159, 28, vars=("name",)),  # false alarm?
+            B023(162, 28, vars=("i",)),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Picking up from https://github.com/PyCQA/flake8-bugbear/compare/main...Zac-HD:flake8-bugbear:B023-false-alarms
Partially fixes #269 

Fixes some common false alarms where a function is immediately consumed, as an argument to `filter` or `reduce`, as a keyword argument to `key=` and as a return value.

**TODO**: I'm not sure how to handle more complex `return` cases, see the last test cases in `b023.py`.

I'm also not sure if this solution is too generous, it currently marks all direct child nodes to calls to `filter`&`reduce` as safe - but @Zac-HD's [comment](https://github.com/PyCQA/flake8-bugbear/issues/269#issuecomment-1172975488) implies it should maybe be stricter:
> Unfortunately it's more difficult to avoid this false alarm than you might think: for example "lambdas are OK if they're the first argument in a call to filter()" would miss bugs where the filter iterable (and therefore lambda) isn't immediately evaluated.


I'm not super read up on the problem and didn't take time to fully understand all comments with false alarms in the original issue, so would love some eyes on this. But it fixes all test cases @Zac-HD added at least.