### PR TITLE
fix typo in unused comparison (B015) message

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1239,7 +1239,7 @@ B014.redundant_exceptions = {
 }
 B015 = Error(
     message=(
-        "B015 Result of comparison is not used. This line doesn't do"
+        "B015 Result of comparison is not used. This line doesn't do "
         "anything. Did you intend to prepend it with assert?"
     )
 )


### PR DESCRIPTION
Thanks so much for this awesome plugin! I just learned about it tonight and tried it out on one of my projects, and it already found a few bugs that `pylint` and standard `flake8` didn't 😍 

While doing that, I saw the following message.

> B015 Result of comparison is not used. This line doesn't doanything. Did you intend to prepend it with assert?

I think `"doanything"` was supposed to be `"do anything"`.

This PR proposes that change.

Thanks for your time and consideration.