### PR TITLE
B027 now ignores @[anything].overload to reduce false positives.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,10 @@ MIT
 Change Log
 ----------
 
+Future
+~~~~~~~~~
+* B027: ignore @overload when typing is import with other names
+
 22.10.27
 ~~~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -671,10 +671,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
         def is_overload(expr):
             return (isinstance(expr, ast.Name) and expr.id == "overload") or (
-                isinstance(expr, ast.Attribute)
-                and isinstance(expr.value, ast.Name)
-                and expr.value.id == "typing"
-                and expr.attr == "overload"
+                isinstance(expr, ast.Attribute) and expr.attr == "overload"
             )
 
         def empty_body(body) -> bool:

--- a/tests/b027.py
+++ b/tests/b027.py
@@ -60,7 +60,10 @@ class NonAbstractClass:
 
 
 # ignore @overload, fixes issue #304
+# ignore overload with other imports, fixes #308
 import typing
+import typing as t
+import typing as anything
 from typing import Union, overload
 
 
@@ -73,6 +76,14 @@ class AstractClass(ABC):
     def empty_1(self, foo: int):
         ...
 
+    @t.overload
+    def empty_1(self, foo: list):
+        ...
+
+    @anything.overload
+    def empty_1(self, foo: float):
+        ...
+
     @abstractmethod
-    def empty_1(self, foo: Union[str, int]):
+    def empty_1(self, foo: Union[str, int, list, float]):
         ...


### PR DESCRIPTION
Fixes #304 

it also ignores `@a.b.c.d.overload` in case somebody is writing a custom overload or importing typing in some *very* weird way - but that seems more likely than disaster striking because the check didn't trigger imo. Didn't bother writing a test for that though