### PR TITLE
Enable module-level checks for B018

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -359,6 +359,10 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b905(node)
         self.generic_visit(node)
 
+    def visit_Module(self, node):
+        self.check_for_b018(node)
+        self.generic_visit(node)
+
     def visit_Assign(self, node):
         if len(node.targets) == 1:
             t = node.targets[0]
@@ -1094,7 +1098,6 @@ class B020NameFinder(NameFinder):
 
 error = namedtuple("error", "lineno col message type vars")
 Error = partial(partial, error, type=BugBearChecker, vars=())
-
 
 B001 = Error(
     message=(

--- a/tests/b018_modules.py
+++ b/tests/b018_modules.py
@@ -1,0 +1,18 @@
+"""
+Should emit:
+B018 - on lines 9-18
+"""
+
+a = 2
+"str"  # Str (no raise)
+f"{int}"  # JoinedStr (no raise)
+1j  # Number (complex)
+1  # Number (int)
+1.0  # Number (float)
+b"foo"  # Binary
+True  # NameConstant (True)
+False  # NameConstant (False)
+None  # NameConstant (None)
+[1, 2]  # list
+{1, 2}  # set
+{"foo": "bar"}  # dict

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -274,6 +274,14 @@ class BugbearTestCase(unittest.TestCase):
         expected.append(B018(33, 4))
         self.assertEqual(errors, self.errors(*expected))
 
+    def test_b018_modules(self):
+        filename = Path(__file__).absolute().parent / "b018_modules.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+
+        expected = [B018(line, 0) for line in range(9, 19)]
+        self.assertEqual(errors, self.errors(*expected))
+
     def test_b019(self):
         filename = Path(__file__).absolute().parent / "b019.py"
         bbc = BugBearChecker(filename=str(filename))


### PR DESCRIPTION
Hi!

This PR addresses #267 and enables B018 checks for module-level statements. I'm doing this by visiting the `Module` component in the AST first, and then any children. Let me know if I've missed anything.

Thanks!