### PR TITLE
Add B017 support for pytest.raises

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -509,6 +509,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
     def check_for_b017(self, node):
         """Checks for use of the evil syntax 'with assertRaises(Exception):'
+        or 'with pytest.raises(Exception)'.
 
         This form of assertRaises will catch everything that subclasses
         Exception, which happens to be the vast majority of Python internal
@@ -518,10 +519,21 @@ class BugBearVisitor(ast.NodeVisitor):
         """
         item = node.items[0]
         item_context = item.context_expr
+
         if (
             hasattr(item_context, "func")
-            and hasattr(item_context.func, "attr")
-            and item_context.func.attr == "assertRaises"
+            and (
+                (
+                    hasattr(item_context.func, "attr")
+                    and item_context.func.attr == "assertRaises"
+                )
+                or (
+                    isinstance(item_context.func, ast.Attribute)
+                    and item_context.func.attr == "raises"
+                    and isinstance(item_context.func.value, ast.Name)
+                    and item_context.func.value.id == "pytest"
+                )
+            )
             and len(item_context.args) == 1
             and isinstance(item_context.args[0], ast.Name)
             and item_context.args[0].id == "Exception"
@@ -1257,11 +1269,11 @@ B016 = Error(
 )
 B017 = Error(
     message=(
-        "B017 assertRaises(Exception): should be considered evil. "
-        "It can lead to your test passing even if the code being tested is "
-        "never executed due to a typo. Either assert for a more specific "
-        "exception (builtin or custom), use assertRaisesRegex, or use the "
-        "context manager form of assertRaises."
+        "B017 assertRaises(Exception): or pytest.raises(Exception) should "
+        "be considered evil. It can lead to your test passing even if the "
+        "code being tested is never executed due to a typo. Either assert "
+        "for a more specific exception (builtin or custom), use "
+        "assertRaisesRegex, or use the context manager form of assertRaises."
     )
 )
 B018 = Error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
@@ -52,6 +53,7 @@ dev = [
     "hypothesis",
     "hypothesmith>=0.2",
     "pre-commit",
+    "pytest",
 ]
 
 [tool.setuptools]

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -1,9 +1,11 @@
 """
 Should emit:
-B017 - on lines 20
+B017 - on lines 24 and 26.
 """
 import asyncio
 import unittest
+
+import pytest
 
 CONSTANT = True
 
@@ -21,16 +23,26 @@ class Foobar(unittest.TestCase):
     def evil_raises(self) -> None:
         with self.assertRaises(Exception):
             raise Exception("Evil I say!")
+        with pytest.raises(Exception):
+            raise Exception("Evil I say!")
 
     def context_manager_raises(self) -> None:
         with self.assertRaises(Exception) as ex:
             raise Exception("Context manager is good")
+        with pytest.raises(Exception) as pyt_ex:
+            raise Exception("Context manager is good")
+
         self.assertEqual("Context manager is good", str(ex.exception))
+        self.assertEqual("Context manager is good", str(pyt_ex.exception))
 
     def regex_raises(self) -> None:
         with self.assertRaisesRegex(Exception, "Regex is good"):
             raise Exception("Regex is good")
+        with pytest.raises(Exception, "Regex is good"):
+            raise Exception("Regex is good")
 
     def raises_with_absolute_reference(self):
         with self.assertRaises(asyncio.CancelledError):
+            Foo()
+        with pytest.raises(asyncio.CancelledError):
             Foo()

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -251,7 +251,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(22, 8))
+        expected = self.errors(B017(24, 8), B017(26, 8))
         self.assertEqual(errors, expected)
 
     def test_b018_functions(self):


### PR DESCRIPTION
Hi! This PR should solve #169, where calls like `with pytest.raises(Exception):` are not being flagged by B017, even though they are basically the same use case as `with self.assertRaises(Exception)`.

I'm uncertain about the best structure for `tests/b017.py`, and I'm open to suggestions here. For now, I've just added the analogous `pytest.raises` calls for each of the test cases with `assertRaises`.