### PR TITLE
B906: ignore functions whose _fields attribute can't contain ast.AST subnodes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -308,6 +308,11 @@ MIT
 Change Log
 ----------
 
+Future
+~~~~~~~~~
+
+* B906: Ignore ``visit_`` functions with a ``_fields`` attribute that can't contain ast.AST subnodes. (#330)
+
 23.1.17
 ~~~~~~~~~
 

--- a/tests/b906.py
+++ b/tests/b906.py
@@ -54,3 +54,33 @@ def a():
 
 def visit_():
     ...
+
+
+# Check exceptions for ast types that only contain ADSL builtin types
+# i.e. don't contain any ast.AST subnodes and therefore don't need a generic_visit
+def visit_alias():
+    ...
+
+
+def visit_Constant():
+    ...
+
+
+def visit_Global():
+    ...
+
+
+def visit_MatchSingleton():
+    ...
+
+
+def visit_MatchStar():
+    ...
+
+
+def visit_Nonlocal():
+    ...
+
+
+def visit_TypeIgnore():
+    ...


### PR DESCRIPTION
fixes #330