### PR TITLE
B906: Add `visit_Bytes`, `visit_Num` and `visit_Str` to the list of ignored `visit_*` functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -311,6 +311,14 @@ MIT
 Change Log
 ----------
 
+Future
+~~~~~~~~~
+
+* B906: Add ``visit_Bytes``, ``visit_Num`` and ``visit_Str`` to the list of ``visit_*``
+  functions that are ignored by the B906 check. The ``ast.Bytes``, ``ast.Num`` and
+  ``ast.Str`` nodes are all deprecated, but may still be used by some codebases in
+  order to maintain backwards compatibility with Python 3.7.
+
 23.1.20
 ~~~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -1018,6 +1018,11 @@ class BugBearVisitor(ast.NodeVisitor):
                 "MatchStar",
                 "Nonlocal",
                 "TypeIgnore",
+                # These ast nodes are deprecated, but some codebases may still use them
+                # for backwards-compatibility with Python 3.7
+                "Bytes",
+                "Num",
+                "Str",
             )
         ):
             return

--- a/tests/b906.py
+++ b/tests/b906.py
@@ -84,3 +84,17 @@ def visit_Nonlocal():
 
 def visit_TypeIgnore():
     ...
+
+
+# These nodes are deprecated, but some codebases may still use them
+# for backwards-compatibility with Python 3.7
+def visit_Bytes():
+    ...
+
+
+def visit_Num():
+    ...
+
+
+def visit_Str():
+    ...


### PR DESCRIPTION
Hi, thanks for flake8-bugbear! I'm a maintainer of [the flake8-pyi plugin](https://github.com/PyCQA/flake8-pyi) for flake8, and I'd love to switch on B906 for our codebase, as I think it's a great idea for a flake8-bugbear check. Unfortunately, however, there's still a false-positive if I switch B906 on over at flake8-pyi, even with the latest release (which includes #335).

The false positive is emitted due to the fact that we have [a `visit_Str` method](https://github.com/PyCQA/flake8-pyi/blob/4778623da8494978dceaec54b0597eea050742ed/pyi.py#L985-L997) in our `ast.NodeVisitor` subclass. `ast.Str` has been deprecated since 3.8, but it's necessary for us to define a `visit_Str` method nonetheless in order to maintain backwards compatibility with Python 3.7.

`ast.Str` nodes have a non-empty `_fields` attribute, but they can't contain any ast subnodes that could be visited, much the same as `ast.alias`, `ast.Constant`, or any of the other nodes special-cased. The same applies for two other deprecated nodes: `ast.Num` and `ast.Bytes`. This PR fixes the false positive on flake8-pyi's codebase by adding `ast.Str`, `ast.Num` and `ast.Bytes` to the list of AST nodes special-cased by B906.