### PR TITLE
Update isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
This PR updates the isort pre-commit hook from 5.11.4 to 5.12.0.

On running the `pre-commit run --all-files` command for the first time, I encountered an error. This seemed to be the same error that was fixed in [this PR for isort](https://github.com/PyCQA/isort/pull/2078), and the update fixes the error.