### PR TITLE
B016: Warn when raising f-strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -319,6 +319,7 @@ Future
   functions that are ignored by the B906 check. The ``ast.Bytes``, ``ast.Num`` and
   ``ast.Str`` nodes are all deprecated, but may still be used by some codebases in
   order to maintain backwards compatibility with Python 3.7.
+* B016: Warn when raising f-strings.
 
 23.1.20
 ~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -516,7 +516,7 @@ class BugBearVisitor(ast.NodeVisitor):
             self.errors.append(B015(node.lineno, node.col_offset))
 
     def check_for_b016(self, node):
-        if isinstance(node.exc, (ast.NameConstant, ast.Num, ast.Str)):
+        if isinstance(node.exc, (ast.NameConstant, ast.Num, ast.Str, ast.JoinedStr)):
             self.errors.append(B016(node.lineno, node.col_offset))
 
     def check_for_b017(self, node):

--- a/tests/b016.py
+++ b/tests/b016.py
@@ -1,11 +1,14 @@
 """
 Should emit:
-B016 - on lines 6, 7, and 8
+B016 - on lines 6, 7, 8, and 10
 """
 
 raise False
 raise 1
 raise "string"
+fstring = "fstring"
+raise f"fstring {fstring}"
 raise Exception(False)
 raise Exception(1)
 raise Exception("string")
+raise Exception(f"fstring {fstring}")

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -247,7 +247,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b016.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B016(6, 0), B016(7, 0), B016(8, 0))
+        expected = self.errors(B016(6, 0), B016(7, 0), B016(8, 0), B016(10, 0))
         self.assertEqual(errors, expected)
 
     def test_b017(self):


### PR DESCRIPTION
Warns when raising f-strings which I think matches the check's current description.