### PR TITLE
Add a lint checking for warnings.warn stacklevel argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ limitations make it difficult.
 **BO28**: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default.
 This will only show a stack trace for the line on which the warn method is called.
 It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
-This warning can be disabled by explicitly setting a stacklevel."
+This warning can be disabled by explicitly setting a stacklevel.
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,11 @@ limitations make it difficult.
 
 **B027**: Empty method in abstract base class, but has no abstract decorator. Consider adding @abstractmethod.
 
+**BO28**: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default.
+This will only show a stack trace for the line on which the warn method is called.
+It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
+This warning can be disabled by explicitly setting a stacklevel."
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -320,6 +325,7 @@ Future
   ``ast.Str`` nodes are all deprecated, but may still be used by some codebases in
   order to maintain backwards compatibility with Python 3.7.
 * B016: Warn when raising f-strings.
+* Add B028: Check for an explicit stacklevel keyword argument on the warn method from the warnings module.
 
 23.1.20
 ~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -173,10 +173,9 @@ limitations make it difficult.
 
 **B027**: Empty method in abstract base class, but has no abstract decorator. Consider adding @abstractmethod.
 
-**BO28**: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default.
-This will only show a stack trace for the line on which the warn method is called.
+**BO28**: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a
+stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called.
 It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
-This warning can be disabled by explicitly setting a stacklevel.
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -1527,8 +1527,7 @@ B028 = Error(
         " warnings module uses a stacklevel of 1 by default. This will only show a"
         " stack trace for the line on which the warn method is called."
         " It is therefore recommended to use a stacklevel of 2 or"
-        " greater to provide more information to the user. This warning can be disabled"
-        " by explicitly setting a stacklevel."
+        " greater to provide more information to the user."
     )
 )
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -360,6 +360,7 @@ class BugBearVisitor(ast.NodeVisitor):
             self.check_for_b026(node)
 
         self.check_for_b905(node)
+        self.check_for_b028(node)
         self.generic_visit(node)
 
     def visit_Module(self, node):
@@ -985,6 +986,16 @@ class BugBearVisitor(ast.NodeVisitor):
         for duplicate in duplicates:
             self.errors.append(B025(node.lineno, node.col_offset, vars=(duplicate,)))
 
+    def check_for_b028(self, node):
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "warn"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "warnings"
+            and not any(kw.arg == "stacklevel" for kw in node.keywords)
+        ):
+            self.errors.append(B028(node.lineno, node.col_offset))
+
     def check_for_b905(self, node):
         if (
             isinstance(node.func, ast.Name)
@@ -1508,6 +1519,16 @@ B027 = Error(
     message=(
         "B027 {} is an empty method in an abstract base class, but has no abstract"
         " decorator. Consider adding @abstractmethod."
+    )
+)
+B028 = Error(
+    message=(
+        "B028 No explicit stacklevel keyword argument found. The warn method from the"
+        " warnings module uses a stacklevel of 1 by default. This will only show a"
+        " stack trace for the line on which the warn method is called."
+        " It is therefore recommended to use a stacklevel of 2 or"
+        " greater to provide more information to the user. This warning can be disabled"
+        " by explicitly setting a stacklevel."
     )
 )
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -986,16 +986,6 @@ class BugBearVisitor(ast.NodeVisitor):
         for duplicate in duplicates:
             self.errors.append(B025(node.lineno, node.col_offset, vars=(duplicate,)))
 
-    def check_for_b028(self, node):
-        if (
-            isinstance(node.func, ast.Attribute)
-            and node.func.attr == "warn"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "warnings"
-            and not any(kw.arg == "stacklevel" for kw in node.keywords)
-        ):
-            self.errors.append(B028(node.lineno, node.col_offset))
-
     def check_for_b905(self, node):
         if (
             isinstance(node.func, ast.Name)
@@ -1156,6 +1146,16 @@ class BugBearVisitor(ast.NodeVisitor):
 
             # if no pre-mark or variable detected, reset state
             current_mark = variable = None
+
+    def check_for_b028(self, node):
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "warn"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "warnings"
+            and not any(kw.arg == "stacklevel" for kw in node.keywords)
+        ):
+            self.errors.append(B028(node.lineno, node.col_offset))
 
 
 def compose_call_path(node):

--- a/tests/b028.py
+++ b/tests/b028.py
@@ -1,0 +1,11 @@
+import warnings
+
+"""
+Should emit:
+B028 - on lines 8 and 9
+"""
+
+warnings.warn(DeprecationWarning("test"))
+warnings.warn(DeprecationWarning("test"), source=None)
+warnings.warn(DeprecationWarning("test"), source=None, stacklevel=2)
+warnings.warn(DeprecationWarning("test"), stacklevel=1)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -39,6 +39,7 @@ from bugbear import (
     B025,
     B026,
     B027,
+    B028,
     B901,
     B902,
     B903,
@@ -428,6 +429,13 @@ class BugbearTestCase(unittest.TestCase):
             B027(23, 4, vars=("empty_4",)),
             B027(31 if sys.version_info >= (3, 8) else 30, 4, vars=("empty_5",)),
         )
+        self.assertEqual(errors, expected)
+
+    def test_b028(self):
+        filename = Path(__file__).absolute().parent / "b028.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(B028(8, 0), B028(9, 0))
         self.assertEqual(errors, expected)
 
     @unittest.skipIf(sys.version_info < (3, 8), "not implemented for <3.8")


### PR DESCRIPTION
This PR adds a lint which checks for an explicitly defined `stacklevel` keyword argument on the `warn` method from the `warnings` module. If `stacklevel` is not explicitly defined, this lint triggers. See #299 for more information.

I am new to this project and ASTs in general, so any feedback is appreciated! Specifically I don't know whether this should be `B028` or `B029`, as `B028` was used before by `B907`.

Closes #299