### PR TITLE
Split B001 into B029 for empty tuple exception handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,7 @@ limitations make it difficult.
 stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called.
 It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
 
-**B029**: Using ``except`` with an empty tuple does not handle anything. Add exceptions to handle instead.
+**B029**: Using ``except: ()`` with an empty tuple does not handle/catch anything. Add exceptions to handle.
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -327,7 +327,7 @@ Future
   order to maintain backwards compatibility with Python 3.7.
 * B016: Warn when raising f-strings.
 * Add B028: Check for an explicit stacklevel keyword argument on the warn method from the warnings module.
-* Add B029: Check when trying to use ``except`` with an empty tuple.
+* Add B029: Check when trying to use ``except`` with an empty tuple i.e. ``except: ()``.
 
 23.1.20
 ~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,8 @@ limitations make it difficult.
 stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called.
 It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
 
+**B029**: Using ``except`` with an empty tuple does not handle anything. Add exceptions to handle instead.
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -325,6 +327,7 @@ Future
   order to maintain backwards compatibility with Python 3.7.
 * B016: Warn when raising f-strings.
 * Add B028: Check for an explicit stacklevel keyword argument on the warn method from the warnings module.
+* Add B029: Check when trying to use ``except`` with an empty tuple.
 
 23.1.20
 ~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -276,15 +276,12 @@ class BugBearVisitor(ast.NodeVisitor):
 
     def visit_ExceptHandler(self, node):
         if node.type is None:
-            self.errors.append(
-                B001(node.lineno, node.col_offset, vars=("bare `except:`",))
-            )
+            self.errors.append(B001(node.lineno, node.col_offset))
         elif isinstance(node.type, ast.Tuple):
             names = [_to_name_str(e) for e in node.type.elts]
             as_ = " as " + node.name if node.name is not None else ""
             if len(names) == 0:
-                vs = (f"`except (){as_}:`",)
-                self.errors.append(B001(node.lineno, node.col_offset, vars=vs))
+                self.errors.append(B029(node.lineno, node.col_offset))
             elif len(names) == 1:
                 self.errors.append(B013(node.lineno, node.col_offset, vars=names))
             else:
@@ -1285,7 +1282,7 @@ Error = partial(partial, error, type=BugBearChecker, vars=())
 
 B001 = Error(
     message=(
-        "B001 Do not use {}, it also catches unexpected "
+        "B001 Do not use bare `except:`, it also catches unexpected "
         "events like memory errors, interrupts, system exit, and so on.  "
         "Prefer `except Exception:`.  If you're sure what you're doing, "
         "be explicit and write `except BaseException:`."
@@ -1528,6 +1525,12 @@ B028 = Error(
         " stack trace for the line on which the warn method is called."
         " It is therefore recommended to use a stacklevel of 2 or"
         " greater to provide more information to the user."
+    )
+)
+B029 = Error(
+    message=(
+        "B029 Using `except` with an empty tuple does not handle anything. "
+        "Add exceptions to handle instead."
     )
 )
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -1529,8 +1529,8 @@ B028 = Error(
 )
 B029 = Error(
     message=(
-        "B029 Using `except` with an empty tuple does not handle anything. "
-        "Add exceptions to handle instead."
+        "B029 Using `except: ()` with an empty tuple does not handle/catch "
+        "anything. Add exceptions to handle."
     )
 )
 

--- a/tests/b001.py
+++ b/tests/b001.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B001 - on lines 8, 40, and 54
+B001 - on lines 8 and 40
 """
 
 try:
@@ -40,10 +40,3 @@ def func(**kwargs):
     except:
         # should be except KeyError:
         return
-
-
-try:
-    pass
-except ():
-    # Literal empty tuple is just like bare except:
-    pass

--- a/tests/b029.py
+++ b/tests/b029.py
@@ -1,0 +1,14 @@
+"""
+Should emit:
+B029 - on lines 8 and 13
+"""
+
+try:
+    pass
+except ():
+    pass
+
+try:
+    pass
+except () as e:
+    pass

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -40,6 +40,7 @@ from bugbear import (
     B026,
     B027,
     B028,
+    B029,
     B901,
     B902,
     B903,
@@ -64,9 +65,8 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B001(8, 0, vars=("bare `except:`",)),
-            B001(40, 4, vars=("bare `except:`",)),
-            B001(47, 0, vars=("`except ():`",)),
+            B001(8, 0),
+            B001(40, 4),
         )
         self.assertEqual(errors, expected)
 
@@ -436,6 +436,16 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(B028(8, 0), B028(9, 0))
+        self.assertEqual(errors, expected)
+
+    def test_b029(self):
+        filename = Path(__file__).absolute().parent / "b029.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B029(8, 0),
+            B029(13, 0),
+        )
         self.assertEqual(errors, expected)
 
     @unittest.skipIf(sys.version_info < (3, 8), "not implemented for <3.8")


### PR DESCRIPTION
This splits the part of B001's lint which checked for using `except` with an empty tuple, and moves it into a new lint, B029. As suggested by the comments in #282. Closes #282.