### PR TITLE
Add B031: Warn when using `groupby()` result multiple times

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,9 @@ It is therefore recommended to use a stacklevel of 2 or greater to provide more 
 
 **B030**: Except handlers should only be exception classes or tuples of exception classes.
 
+**B031**: Using the generator returned from `itertools.groupby()` more than once will do nothing on the
+second usage. Save the result to a list if the result is needed multiple times.
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/b031.py
+++ b/tests/b031.py
@@ -1,0 +1,64 @@
+"""
+Should emit:
+B030 - on lines 29, 33, 43
+"""
+import itertools
+from itertools import groupby
+
+shoppers = ["Jane", "Joe", "Sarah"]
+items = [
+    ("lettuce", "greens"),
+    ("tomatoes", "greens"),
+    ("cucumber", "greens"),
+    ("chicken breast", "meats & fish"),
+    ("salmon", "meats & fish"),
+    ("ice cream", "frozen items"),
+]
+
+carts = {shopper: [] for shopper in shoppers}
+
+
+def collect_shop_items(shopper, items):
+    # Imagine this an expensive database query or calculation that is
+    # advantageous to batch.
+    carts[shopper] += items
+
+
+# Group by shopping section
+for _section, section_items in groupby(items, key=lambda p: p[1]):
+    for shopper in shoppers:
+        collect_shop_items(shopper, section_items)
+
+for _section, section_items in groupby(items, key=lambda p: p[1]):
+    collect_shop_items("Jane", section_items)
+    collect_shop_items("Joe", section_items)
+
+
+for _section, section_items in groupby(items, key=lambda p: p[1]):
+    # This is ok
+    collect_shop_items("Jane", section_items)
+
+for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
+    for shopper in shoppers:
+        collect_shop_items(shopper, section_items)
+
+for group in groupby(items, key=lambda p: p[1]):
+    # This is bad, but not detected currently
+    collect_shop_items("Jane", group[1])
+    collect_shop_items("Joe", group[1])
+
+
+#  Make sure we ignore - but don't fail on more complicated invocations
+for _key, (_value1, _value2) in groupby(
+    [("a", (1, 2)), ("b", (3, 4)), ("a", (5, 6))], key=lambda p: p[1]
+):
+    collect_shop_items("Jane", group[1])
+    collect_shop_items("Joe", group[1])
+
+#  Make sure we ignore - but don't fail on more complicated invocations
+for (_key1, _key2), (_value1, _value2) in groupby(
+    [(("a", "a"), (1, 2)), (("b", "b"), (3, 4)), (("a", "a"), (5, 6))],
+    key=lambda p: p[1],
+):
+    collect_shop_items("Jane", group[1])
+    collect_shop_items("Joe", group[1])

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -42,6 +42,7 @@ from bugbear import (
     B028,
     B029,
     B030,
+    B031,
     B901,
     B902,
     B903,
@@ -456,6 +457,17 @@ class BugbearTestCase(unittest.TestCase):
         expected = self.errors(
             B030(8, 0),
             B030(13, 0),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b031(self):
+        filename = Path(__file__).absolute().parent / "b031.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B031(30, 36, vars=("section_items",)),
+            B031(34, 30, vars=("section_items",)),
+            B031(43, 36, vars=("section_items",)),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
I ran into a somewhat subtle bug by accidentally iterating over the result of `itertools.groupby()` twice:

```python
from itertools import groupby

items = [
    ('lettuce', 'greens'),
    ('tomatoes', 'greens'),
    ('chicken breast', 'meats & fish'),
]

# Group by shopping section
for _section, section_items in groupby(items, key=lambda p: p[1]):
    for shopper in ['Jane', 'Joe']:
        collect_shop_items(shopper, section_items) # "Joe" won't get any items
        # assuming that `collect_shop_items()` iterates over `section_items`
```

I've written B031 ([since there's a PR open for B030](https://github.com/PyCQA/flake8-bugbear/pull/346)) to detect these types of erroneous usages.

There are likely other functions in `itertools` that return generators and should potentially be covered by this check.
Also, the check is fairly rudimentary. It only works if the `groupby()` is used in a loop and unpacked directly into a tuple as shown above.

Another subtle thing about `groupby()` is that it only groups when the items are sorted (but this doesn't cover that).