### PR TITLE
B032: Possible unintentional type annotations instead of assignments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,6 +184,8 @@ It is therefore recommended to use a stacklevel of 2 or greater to provide more 
 **B031**: Using the generator returned from `itertools.groupby()` more than once will do nothing on the
 second usage. Save the result to a list if the result is needed multiple times.
 
+**B032**: Possible unintentional type annotation (using ``:``). Did you mean to assign (using ``=``)?
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -333,6 +335,7 @@ Future
 * B016: Warn when raising f-strings.
 * Add B028: Check for an explicit stacklevel keyword argument on the warn method from the warnings module.
 * Add B029: Check when trying to use ``except`` with an empty tuple i.e. ``except: ()``.
+* Add B032: Check for possible unintentional type annotations instead of assignments.
 
 23.1.20
 ~~~~~~~~~

--- a/tests/b032.py
+++ b/tests/b032.py
@@ -1,0 +1,29 @@
+"""
+Should emit:
+B032 - on lines 9, 10, 12, 13, 16-19
+"""
+
+# Flag these
+dct = {"a": 1}
+
+dct["b"]: 2
+dct.b: 2
+
+dct["b"]: "test"
+dct.b: "test"
+
+test = "test"
+dct["b"]: test
+dct["b"]: test.lower()
+dct.b: test
+dct.b: test.lower()
+
+# Do not flag below
+typed_dct: dict[str, int] = {"a": 1}
+typed_dct["b"] = 2
+typed_dct.b = 2
+
+
+class TestClass:
+    def test_self(self):
+        self.test: int

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -43,6 +43,7 @@ from bugbear import (
     B029,
     B030,
     B031,
+    B032,
     B901,
     B902,
     B903,
@@ -468,6 +469,22 @@ class BugbearTestCase(unittest.TestCase):
             B031(30, 36, vars=("section_items",)),
             B031(34, 30, vars=("section_items",)),
             B031(43, 36, vars=("section_items",)),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b032(self):
+        filename = Path(__file__).absolute().parent / "b032.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B032(9, 0),
+            B032(10, 0),
+            B032(12, 0),
+            B032(13, 0),
+            B032(16, 0),
+            B032(17, 0),
+            B032(18, 0),
+            B032(19, 0),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
This lint checks for possibly mistakenly using `:` (for type annotations) instead of `=` (for assigning).

Closes #312.