### PR TITLE
B005: Do not flag on imported modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -325,6 +325,11 @@ MIT
 Change Log
 ----------
 
+Future
+~~~~~~~~~
+
+* B005: Do not flag when using the ``strip()`` method on an imported module.
+
 23.2.13
 ~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-* B905: Do not flag when using the ``strip()`` method on an imported module.
+* B005: Do not flag when using the ``strip()`` method on an imported module.
 * B030: Allow calls and starred expressions in except handlers.
 
 23.2.13

--- a/bugbear.py
+++ b/bugbear.py
@@ -293,6 +293,7 @@ class BugBearVisitor(ast.NodeVisitor):
 
     NODE_WINDOW_SIZE = 4
     _b023_seen = attr.ib(factory=set, init=False)
+    _b005_imports = attr.ib(factory=set, init=False)
 
     if False:
         # Useful for tracing what the hell is going on.
@@ -486,25 +487,39 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b032(node)
         self.generic_visit(node)
 
+    def visit_Import(self, node):
+        self.check_for_b005(node)
+        self.generic_visit(node)
+
     def check_for_b005(self, node):
-        if node.func.attr not in B005.methods:
-            return  # method name doesn't match
+        if isinstance(node, ast.Import):
+            for name in node.names:
+                self._b005_imports.add(name.asname or name.name)
+        elif isinstance(node, ast.Call):
+            if node.func.attr not in B005.methods:
+                return  # method name doesn't match
 
-        if len(node.args) != 1 or not isinstance(node.args[0], ast.Str):
-            return  # used arguments don't match the builtin strip
+            if (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in self._b005_imports
+            ):
+                return  # method is being run on an imported module
 
-        call_path = ".".join(compose_call_path(node.func.value))
-        if call_path in B005.valid_paths:
-            return  # path is exempt
+            if len(node.args) != 1 or not isinstance(node.args[0], ast.Str):
+                return  # used arguments don't match the builtin strip
 
-        s = node.args[0].s
-        if len(s) == 1:
-            return  # stripping just one character
+            call_path = ".".join(compose_call_path(node.func.value))
+            if call_path in B005.valid_paths:
+                return  # path is exempt
 
-        if len(s) == len(set(s)):
-            return  # no characters appear more than once
+            s = node.args[0].s
+            if len(s) == 1:
+                return  # stripping just one character
 
-        self.errors.append(B005(node.lineno, node.col_offset))
+            if len(s) == len(set(s)):
+                return  # no characters appear more than once
+
+            self.errors.append(B005(node.lineno, node.col_offset))
 
     def check_for_b006_and_b008(self, node):
         visitor = FuntionDefDefaultsVisitor(self.b008_extend_immutable_calls)

--- a/tests/b005.py
+++ b/tests/b005.py
@@ -25,9 +25,7 @@ other_type().lstrip()  # no warning
 other_type().rstrip(["a", "b", "c"])  # no warning
 other_type().strip("a", "b")  # no warning
 
-import test
-
-import test2
+import test, test2  # isort: skip
 import test_as as test3
 
 test.strip("test")  # no warning

--- a/tests/b005.py
+++ b/tests/b005.py
@@ -24,3 +24,12 @@ strip("we")  # no warning
 other_type().lstrip()  # no warning
 other_type().rstrip(["a", "b", "c"])  # no warning
 other_type().strip("a", "b")  # no warning
+
+import test
+
+import test2
+import test_as as test3
+
+test.strip("test")  # no warning
+test2.strip("test")  # no warning
+test3.strip("test")  # no warning


### PR DESCRIPTION
This PR changes B005 so that it does not flag when the `strip()` method is used on an imported module such as this:
```python
import test

test.strip("test")
```

I'm not entirely sure if `BugBearVisitor` is the correct place to define `_b005_imports` so please let me know if there's a better place.

This closes #297, but we might want to open a new issue for the configuration of excluded methods, if we want to add that as well.