### PR TITLE
B030: allow splats and calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -325,6 +325,11 @@ MIT
 Change Log
 ----------
 
+Unreleased
+~~~~~~~~~~
+
+* B030: Allow calls and starred expressions in except handlers.
+
 23.2.13
 ~~~~~~~~~
 

--- a/tests/b030.py
+++ b/tests/b030.py
@@ -12,3 +12,18 @@ try:
     pass
 except (1, ValueError):  # error
     pass
+
+try:
+    pass
+except (ValueError, *(RuntimeError, TypeError)):  # ok
+    pass
+
+
+def what_to_catch():
+    return (ValueError, TypeError)
+
+
+try:
+    pass
+except what_to_catch():  # ok
+    pass


### PR DESCRIPTION
Fixes #352.

I allow calls in addition to splats because a real-world false positive was reported
and buggy code doesn't seem common enough to merit an on-by-default error.
