### PR TITLE
B950: Ignores 'noqa' and 'type: ignore' comments (#162)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ This is meant to be enabled by developers writing visitors using the ``ast`` mod
 
 **B950**: Line too long. This is a pragmatic equivalent of
 ``pycodestyle``'s ``E501``: it considers "max-line-length" but only triggers
-when the value has been exceeded by **more than 10%**. You will no
+when the value has been exceeded by **more than 10%**. ``noqa`` and ``type: ignore`` comments are ignored. You will no
 longer be forced to reformat code due to the closing parenthesis being
 one character too far to satisfy the linter. At the same time, if you do
 significantly violate the line length, you will receive a message that

--- a/bugbear.py
+++ b/bugbear.py
@@ -68,28 +68,29 @@ class BugBearChecker:
 
         The following simple checks are based on the raw lines, not the AST.
         """
-        noqa_type_ignore_regex = re.compile(r"\s*#\s*(noqa:|type:\s*ignore).*$")
+        noqa_type_ignore_regex = re.compile(r"#\s*(noqa|type:\s*ignore)[^#\r\n]*$")
         for lineno, line in enumerate(self.lines, start=1):
             # Special case: ignore long shebang (following pycodestyle).
             if lineno == 1 and line.startswith("#!"):
                 continue
 
             # At first, removing noqa and type: ignore trailing comments"
-            line = noqa_type_ignore_regex.sub("", line)
+            line_without_first_comment = noqa_type_ignore_regex.sub("", line)
+            no_comment_line = noqa_type_ignore_regex.sub("", line_without_first_comment)
 
-            length = len(line) - 1
-            if length > 1.1 * self.max_line_length and line.strip():
+            length = len(no_comment_line) - 1
+            if length > 1.1 * self.max_line_length and no_comment_line.strip():
                 # Special case long URLS and paths to follow pycodestyle.
                 # Would use the `pycodestyle.maximum_line_length` directly but
                 # need to supply it arguments that are not available so chose
                 # to replicate instead.
-                chunks = line.split()
+                chunks = no_comment_line.split()
 
                 is_line_comment_url_path = len(chunks) == 2 and chunks[0] == "#"
 
                 just_long_url_path = len(chunks) == 1
 
-                num_leading_whitespaces = len(line) - len(chunks[-1])
+                num_leading_whitespaces = len(no_comment_line) - len(chunks[-1])
                 too_many_leading_white_spaces = (
                     num_leading_whitespaces >= self.max_line_length - 7
                 )

--- a/bugbear.py
+++ b/bugbear.py
@@ -75,8 +75,9 @@ class BugBearChecker:
                 continue
 
             # At first, removing noqa and type: ignore trailing comments"
-            line_without_first_comment = noqa_type_ignore_regex.sub("", line)
-            no_comment_line = noqa_type_ignore_regex.sub("", line_without_first_comment)
+            no_comment_line = noqa_type_ignore_regex.sub("", line)
+            if no_comment_line != line:
+                no_comment_line = noqa_type_ignore_regex.sub("", no_comment_line)
 
             length = len(no_comment_line) - 1
             if length > 1.1 * self.max_line_length and no_comment_line.strip():

--- a/bugbear.py
+++ b/bugbear.py
@@ -68,10 +68,14 @@ class BugBearChecker:
 
         The following simple checks are based on the raw lines, not the AST.
         """
+        noqa_type_ignore_regex = re.compile(r"\s*#\s*(noqa:|type:\s*ignore).*$")
         for lineno, line in enumerate(self.lines, start=1):
             # Special case: ignore long shebang (following pycodestyle).
             if lineno == 1 and line.startswith("#!"):
                 continue
+
+            # At first, removing noqa and type: ignore trailing comments"
+            line = noqa_type_ignore_regex.sub("", line)
 
             length = len(line) - 1
             if length > 1.1 * self.max_line_length and line.strip():

--- a/tests/b950.py
+++ b/tests/b950.py
@@ -24,9 +24,13 @@
 """
                                                                                                                                                                 
 """
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # noqa"
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # type: ignore"
 "https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # noqa: F401"
 "https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com#noqa:F401, B950"
 "https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # type: ignore[some-code]"
 "https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com # type: ignore[some-code]"
 "https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com # type: ignore[some-code] # noqa: F401"
 "https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # noqa: F401 # type:ignore[some-code]"
+"NOT OK: https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # noqa"
+"NOT OK: https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # type: ignore"

--- a/tests/b950.py
+++ b/tests/b950.py
@@ -24,3 +24,9 @@
 """
                                                                                                                                                                 
 """
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # noqa: F401"
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com#noqa:F401, B950"
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # type: ignore[some-code]"
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com # type: ignore[some-code]"
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com # type: ignore[some-code] # noqa: F401"
+"https://foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.com  # noqa: F401 # type:ignore[some-code]"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -707,6 +707,8 @@ class BugbearTestCase(unittest.TestCase):
                 B950(12, 103, vars=(103, 79)),
                 B950(14, 103, vars=(103, 79)),
                 B950(21, 97, vars=(97, 79)),
+                B950(35, 104, vars=(104, 79)),
+                B950(36, 104, vars=(104, 79)),
             ),
         )
 
@@ -725,6 +727,8 @@ class BugbearTestCase(unittest.TestCase):
                 B950(12, 103, vars=(103, 79)),
                 B950(14, 103, vars=(103, 79)),
                 B950(21, 97, vars=(97, 79)),
+                B950(35, 104, vars=(104, 79)),
+                B950(36, 104, vars=(104, 79)),
             ),
         )
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -689,6 +689,8 @@ class BugbearTestCase(unittest.TestCase):
                 B950(12, 103, vars=(103, 79)),
                 B950(14, 103, vars=(103, 79)),
                 B950(21, 97, vars=(97, 79)),
+                B950(35, 104, vars=(104, 79)),
+                B950(36, 104, vars=(104, 79)),
             ),
         )
 


### PR DESCRIPTION
Implements #162 

`noqa` and `type: ignore` comments won't be taken into account when checking lines.

In my proposal I use a regular expression, to remove and thus ignore the comments mentioned in the issue.