### PR TITLE
Fix typos in docstring

### DIFF
--- a/tests/b031.py
+++ b/tests/b031.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B030 - on lines 29, 33, 43
+B031 - on lines 30, 34, 43
 """
 import itertools
 from itertools import groupby


### PR DESCRIPTION
Change the docstring to the correct code. Change the line numbers that are expected to trigger the warning code.