### PR TITLE
Fix bug in b030

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -190,11 +190,17 @@ def _is_identifier(arg):
 
 
 def _flatten_excepthandler(node):
-    if isinstance(node, ast.Tuple):
-        for elt in node.elts:
-            yield from _flatten_excepthandler(elt)
-    else:
+    if not isinstance(node, ast.Tuple):
         yield node
+        return
+    exprs_to_flatten = [node.elts]
+    while len(exprs_to_flatten):
+        exprs = exprs_to_flatten.pop()
+        for expr in exprs:
+            if isinstance(expr, ast.Starred) and isinstance(expr.value, (ast.List, ast.Tuple)):
+                exprs_to_flatten.append(expr.value.elts)
+                continue
+            yield expr
 
 
 def _check_redundant_excepthandlers(names, node):

--- a/bugbear.py
+++ b/bugbear.py
@@ -196,7 +196,9 @@ def _flatten_excepthandler(node):
     expr_list = node.elts.copy()
     while len(expr_list):
         expr = expr_list.pop(0)
-        if isinstance(expr, ast.Starred) and isinstance(expr.value, (ast.List, ast.Tuple)):
+        if isinstance(expr, ast.Starred) and isinstance(
+            expr.value, (ast.List, ast.Tuple)
+        ):
             expr_list.extend(expr.value.elts)
             continue
         yield expr

--- a/bugbear.py
+++ b/bugbear.py
@@ -193,14 +193,13 @@ def _flatten_excepthandler(node):
     if not isinstance(node, ast.Tuple):
         yield node
         return
-    exprs_to_flatten = [node.elts]
-    while len(exprs_to_flatten):
-        exprs = exprs_to_flatten.pop()
-        for expr in exprs:
-            if isinstance(expr, ast.Starred) and isinstance(expr.value, (ast.List, ast.Tuple)):
-                exprs_to_flatten.append(expr.value.elts)
-                continue
-            yield expr
+    expr_list = node.elts.copy()
+    while len(expr_list):
+        expr = expr_list.pop(0)
+        if isinstance(expr, ast.Starred) and isinstance(expr.value, (ast.List, ast.Tuple)):
+            expr_list.extend(expr.value.elts)
+            continue
+        yield expr
 
 
 def _check_redundant_excepthandlers(names, node):

--- a/tests/b030.py
+++ b/tests/b030.py
@@ -1,6 +1,11 @@
 try:
     pass
-except (ValueError, (RuntimeError, (KeyError, TypeError))):  # ok
+except (ValueError, (RuntimeError, (KeyError, TypeError))):  # error
+    pass
+
+try:
+    pass
+except (ValueError, *(RuntimeError, *(KeyError, TypeError))):  # ok
     pass
 
 try:

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -456,8 +456,9 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B030(8, 0),
+            B030(3, 0),
             B030(13, 0),
+            B030(18, 0),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
I was working in ruff implementing B030 when I noticed that the test case for the warning didn't look right. It may be that another rule catches this issue, but it made sense to me that B030 would catch it as well.

```python
try:
    raise ValueError()
except (ValueError, (RuntimeError, (KeyError, TypeError))):
    pass
```

This code causes an exception, `TypeError: catching classes that do not inherit from BaseException is not allowed`, because the inner tuple isn't expanded out automatically. It passes, however, if those tuples are starred:

```python
try:
    raise ValueError()
except (ValueError, *(RuntimeError, *(KeyError, TypeError))):
    pass
```

The wording for B030 makes it sound like this is the exact error it's meant to catch, so I updated the `_flatten_excepthandler` method to be more selective when flattening tuples and arrays. In the updated code, the `(RuntimeError, ...)` tuple is returned fully, which then gets it placed in the bad_handlers list.

Let me know if there's anything I missed, any improvements I can make, or if I should have started this convo in an issue. I had already gotten this logic working in Rust, so I tried to port it into python and plug it in to see if I could get the same result. Work was already done, so I figured a PR was a decent way to present it.