### PR TITLE
(3.8) Update CI and metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
         os: [ubuntu-latest]
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@ We use GitHub. To get started I'd suggest visiting https://guides.github.com/
 
 Please make sure you system has the following:
 
-- Python 3.7.0 or greater
+- Python 3.8.0 or greater
 - git cli client
 
 Also ensure you can authenticate with GitHub via SSH Keys or HTTPS.
@@ -55,7 +55,7 @@ You can also use [tox](https://tox.wiki/en/latest/index.html) to test with multi
 ```console
 /path/to/venv/bin/tox
 ```
-will by default run all tests on python versions 3.7 through 3.11. If you only want to test a specific version you can specify the environment with `-e`
+will by default run all tests on python versions 3.8 through 3.11. If you only want to test a specific version you can specify the environment with `-e`
 
 ```console
 /path/to/venv/bin/tox -e py38

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = ["flake8 >= 3.0.0", "attrs>=19.2.0"]
 dynamic = ["version"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 # The test environment and commands
 [tox]
 # default environments to run without `-e`
-envlist = py37, py38, py39, py310, py311
+envlist = py38, py39, py310, py311
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
Tracking issue: #365

Updates CI to remove 3.7 runs and updates project metadata from 3.7 to 3.8.

Will be needed for CI to run on #366
