### PR TITLE
(3.8) Minor tweaks

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -135,7 +135,7 @@ class BugBearChecker:
             help="Skip B008 test for additional immutable calls.",
         )
 
-    @lru_cache()  # noqa: B019
+    @lru_cache  # noqa: B019
     def should_warn(self, code):
         """Returns `True` if Bugbear should emit a particular warning.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.8.1"
 dependencies = ["flake8 >= 3.0.0", "attrs>=19.2.0"]
 dynamic = ["version"]
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -747,8 +747,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent.parent / "bugbear.py"
         proc = subprocess.run(
             ["flake8", str(filename)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=60,
         )
         self.assertEqual(proc.returncode, 0, proc.stdout.decode("utf8"))
@@ -759,8 +758,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute()
         proc = subprocess.run(
             ["flake8", str(filename)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=60,
         )
         self.assertEqual(proc.returncode, 0, proc.stdout.decode("utf8"))

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.10: py310
     3.11: py311
 
-[testenv:{py37, py38, py39, py310, py311}]
+[testenv:{py38, py39, py310, py311}]
 description = Run coverage
 deps =
     coverage


### PR DESCRIPTION
Tracking issue: #365

Some minor changes:
- Changes in `bugbear.py` and `test_bugbear.py` from running `pyupgrade --py38-plus` against them (I left the individual test files, not sure if we want to change those)
- A change to `pyproject.toml` setting `requires-python` to `>=3.8.1` instead of `>=3.8` to match flake8
- A change I missed in `tox.ini` on #367

Should we also change the `flake8` dependency requirement from `>=3.0.0` to `>=6.0.0`?