### PR TITLE
Add B033: Duplicate items in sets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,8 @@ second usage. Save the result to a list if the result is needed multiple times.
 
 **B032**: Possible unintentional type annotation (using ``:``). Did you mean to assign (using ``=``)?
 
+**B033**: Sets should not contain duplicate items. Duplicate items will be replaced with a single item at runtime.
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -329,6 +331,7 @@ Unreleased
 ~~~~~~~~~~
 
 * B030: Fix crash on certain unusual except handlers (e.g. ``except a[0].b:``)
+* Add B033: Check for duplicate items in sets.
 
 23.3.12
 ~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -310,7 +310,6 @@ class BugBearVisitor(ast.NodeVisitor):
     NODE_WINDOW_SIZE = 4
     _b023_seen = attr.ib(factory=set, init=False)
     _b005_imports = attr.ib(factory=set, init=False)
-    _b033_seen = attr.ib(factory=set, init=False)
 
     if False:
         # Useful for tracing what the hell is going on.
@@ -1314,12 +1313,12 @@ class BugBearVisitor(ast.NodeVisitor):
             self.errors.append(B032(node.lineno, node.col_offset))
 
     def check_for_b033(self, node):
-        self._b033_seen.clear()
-        for item in filter(lambda x: isinstance(x, ast.Constant), node.elts):
-            if item.value in self._b033_seen:
-                self.errors.append(B033(node.lineno, node.col_offset))
-                break
-            self._b033_seen.add(item.value)
+        constants = [
+            item.value
+            for item in filter(lambda x: isinstance(x, ast.Constant), node.elts)
+        ]
+        if len(constants) != len(set(constants)):
+            self.errors.append(B033(node.lineno, node.col_offset))
 
 
 def compose_call_path(node):

--- a/tests/b033.py
+++ b/tests/b033.py
@@ -1,0 +1,17 @@
+"""
+Should emit:
+B033 - on lines 6-12
+"""
+
+test = {1, 2, 3, 3, 5}
+test = {"a", "b", "c", "c", "e"}
+test = {True, False, True}
+test = {None, True, None}
+test = {3, 3.0}
+test = {1, True}
+test = {0, False}
+
+test = {1, 2, 3, 3.5, 5}
+test = {"a", "b", "c", "d", "e"}
+test = {True, False}
+test = {None}

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -44,6 +44,7 @@ from bugbear import (
     B030,
     B031,
     B032,
+    B033,
     B901,
     B902,
     B903,
@@ -486,6 +487,21 @@ class BugbearTestCase(unittest.TestCase):
             B032(17, 0),
             B032(18, 0),
             B032(19, 0),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b033(self):
+        filename = Path(__file__).absolute().parent / "b033.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B033(6, 7),
+            B033(7, 7),
+            B033(8, 7),
+            B033(9, 7),
+            B033(10, 7),
+            B033(11, 7),
+            B033(12, 7),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
This checks for duplicate items in sets when using the `{}` syntax.

Adds a part of #371.