### PR TITLE
(3.8) Remove outdated sys.version_info checks

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1174,11 +1174,6 @@ class BugBearVisitor(ast.NodeVisitor):
             self.errors.append(B906(node.lineno, node.col_offset))
 
     def check_for_b907(self, node: ast.JoinedStr):  # noqa: C901
-        # AST structure of strings in f-strings in 3.7 is different enough this
-        # implementation doesn't work
-        if sys.version_info <= (3, 7):
-            return  # pragma: no cover
-
         def myunparse(node: ast.AST) -> str:  # pragma: no cover
             if sys.version_info >= (3, 9):
                 return ast.unparse(node)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -120,7 +120,7 @@ class BugbearTestCase(unittest.TestCase):
                 B006(72, 19),
                 B006(76, 31),
                 B006(80, 25),
-                B006(85, 45 if sys.version_info >= (3, 8) else 46),
+                B006(85, 45),
                 B008(85, 60),
                 B006(89, 45),
                 B008(89, 63),
@@ -130,7 +130,7 @@ class BugbearTestCase(unittest.TestCase):
                 B008(109, 38),
                 B008(113, 11),
                 B008(113, 31),
-                B008(117, 29 if sys.version_info >= (3, 8) else 30),
+                B008(117, 29),
                 B008(160, 29),
                 B008(164, 44),
                 B006(170, 19),
@@ -293,20 +293,17 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b019.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-
-        # AST Decorator column location for callable decorators changes in 3.7
-        col = 5 if sys.version_info >= (3, 7) else 4
         self.assertEqual(
             errors,
             self.errors(
                 B019(73, 5),
                 B019(77, 5),
-                B019(81, col),
-                B019(85, col),
+                B019(81, 5),
+                B019(85, 5),
                 B019(89, 5),
                 B019(93, 5),
-                B019(97, col),
-                B019(101, col),
+                B019(97, 5),
+                B019(101, 5),
             ),
         )
 
@@ -430,7 +427,7 @@ class BugbearTestCase(unittest.TestCase):
             B027(16, 4, vars=("empty_2",)),
             B027(19, 4, vars=("empty_3",)),
             B027(23, 4, vars=("empty_4",)),
-            B027(31 if sys.version_info >= (3, 8) else 30, 4, vars=("empty_5",)),
+            B027(31, 4, vars=("empty_5",)),
         )
         self.assertEqual(errors, expected)
 
@@ -489,7 +486,6 @@ class BugbearTestCase(unittest.TestCase):
         )
         self.assertEqual(errors, expected)
 
-    @unittest.skipIf(sys.version_info < (3, 8), "not implemented for <3.8")
     def test_b907(self):
         filename = Path(__file__).absolute().parent / "b907.py"
         bbc = BugBearChecker(filename=str(filename))
@@ -537,7 +533,6 @@ class BugbearTestCase(unittest.TestCase):
     # manual permutations to save overhead when doing >60k permutations
     # see format spec at
     # https://docs.python.org/3/library/string.html#format-specification-mini-language
-    @unittest.skipIf(sys.version_info < (3, 8), "not implemented for <3.8")
     def test_b907_format_specifier_permutations(self):
         visitor = BugBearVisitor(filename="", lines="")
 
@@ -615,7 +610,6 @@ class BugbearTestCase(unittest.TestCase):
             ),
         )
 
-    @unittest.skipIf(sys.version_info < (3, 8), "requires 3.8+")
     def test_b902_py38(self):
         filename = Path(__file__).absolute().parent / "b902_py38.py"
         bbc = BugBearChecker(filename=str(filename))


### PR DESCRIPTION
Tracking issue: #365

Removes outdated `sys.version_info` checks which we don't need with our minimum Python version of 3.8.1.