### PR TITLE
Improve B033 (duplicate set items)

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1356,7 +1356,9 @@ class BugBearVisitor(ast.NodeVisitor):
             if not isinstance(elt, ast.Constant):
                 continue
             if elt.value in seen:
-                self.errors.append(B033(elt.lineno, elt.col_offset, vars=(repr(elt.value),)))
+                self.errors.append(
+                    B033(elt.lineno, elt.col_offset, vars=(repr(elt.value),))
+                )
             else:
                 seen.add(elt.value)
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -1761,8 +1761,8 @@ B032 = Error(
 
 B033 = Error(
     message=(
-        "B033 Set should not contain duplicate item {}. Duplicate items will be replaced"
-        " with a single item at runtime."
+        "B033 Set should not contain duplicate item {}. Duplicate items will be"
+        " replaced with a single item at runtime."
     )
 )
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -1351,12 +1351,14 @@ class BugBearVisitor(ast.NodeVisitor):
             self.errors.append(B032(node.lineno, node.col_offset))
 
     def check_for_b033(self, node):
-        constants = [
-            item.value
-            for item in filter(lambda x: isinstance(x, ast.Constant), node.elts)
-        ]
-        if len(constants) != len(set(constants)):
-            self.errors.append(B033(node.lineno, node.col_offset))
+        seen = set()
+        for elt in node.elts:
+            if not isinstance(elt, ast.Constant):
+                continue
+            if elt.value in seen:
+                self.errors.append(B033(elt.lineno, elt.col_offset, vars=(repr(elt.value),)))
+            else:
+                seen.add(elt.value)
 
 
 def compose_call_path(node):
@@ -1757,7 +1759,7 @@ B032 = Error(
 
 B033 = Error(
     message=(
-        "B033 Sets should not contain duplicate items. Duplicate items will be replaced"
+        "B033 Set should not contain duplicate item {}. Duplicate items will be replaced"
         " with a single item at runtime."
     )
 )

--- a/tests/b033.py
+++ b/tests/b033.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B033 - on lines 6-12 and 16
+B033 - on lines 6-12, 16, 18
 """
 
 test = {1, 2, 3, 3, 5}
@@ -14,6 +14,8 @@ multi_line = {
     "alongvalueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
     1,
     True,
+    0,
+    False,
 }
 
 test = {1, 2, 3, 3.5, 5}

--- a/tests/b033.py
+++ b/tests/b033.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B033 - on lines 6-12
+B033 - on lines 6-12 and 16
 """
 
 test = {1, 2, 3, 3, 5}
@@ -10,6 +10,11 @@ test = {None, True, None}
 test = {3, 3.0}
 test = {1, True}
 test = {0, False}
+multi_line = {
+    "alongvalueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    1,
+    True,
+}
 
 test = {1, 2, 3, 3.5, 5}
 test = {"a", "b", "c", "d", "e"}

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -501,6 +501,7 @@ class BugbearTestCase(unittest.TestCase):
             B033(11, 11, vars=("True",)),
             B033(12, 11, vars=("False",)),
             B033(16, 4, vars=("True",)),
+            B033(18, 4, vars=("False",)),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -493,13 +493,14 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B033(6, 7),
-            B033(7, 7),
-            B033(8, 7),
-            B033(9, 7),
-            B033(10, 7),
-            B033(11, 7),
-            B033(12, 7),
+            B033(6, 17, vars=("3",)),
+            B033(7, 23, vars=("'c'",)),
+            B033(8, 21, vars=("True",)),
+            B033(9, 20, vars=("None",)),
+            B033(10, 11, vars=("3.0",)),
+            B033(11, 11, vars=("True",)),
+            B033(12, 11, vars=("False",)),
+            B033(16, 4, vars=("True",)),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
- Include the repr() of the duplicate item in the error
- Point the error directly at the duplicate item

Fixes #384
