### PR TITLE
add `tox.ini` in `sdist`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include *.rst LICENSE
+include *.rst LICENSE tox.ini
 recursive-include tests *.txt *.py


### PR DESCRIPTION
close https://github.com/PyCQA/flake8-bugbear/issues/383

This PR adds `tox.ini` in `MANIFEST.in` for downstream testing.