### PR TITLE
Avoid another source of deprecation warnings on py312

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -5,6 +5,7 @@ import logging
 import math
 import re
 import sys
+import warnings
 from collections import namedtuple
 from contextlib import suppress
 from functools import lru_cache, partial
@@ -1182,7 +1183,12 @@ class BugBearVisitor(ast.NodeVisitor):
 
         # extract what's visited
         class_name = node.name[len("visit_") :]
-        class_type = getattr(ast, class_name, None)
+
+        # silence any DeprecationWarnings
+        # that might come from accessing a deprecated AST node
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            class_type = getattr(ast, class_name, None)
 
         if (
             # not a valid ast subclass


### PR DESCRIPTION
Running flake8 (with flake8-bugbear installed) using Python 3.12 on a file containing this...

```py
class Foo:
    def visit_NameConstant(self):
        ...
```

...will cause this DeprecationWarning to be emitted:

```pytb
flake8-bugbear\bugbear.py:1185: DeprecationWarning: ast.NameConstant is deprecated and will be removed in Python 3.14; use ast.Constant instead
  class_type = getattr(ast, class_name, None)
```

This is because of this line here -- doing `getattr(ast, "Bytes", None)` causes a DeprecationWarning to be emitted on Python 3.12:

https://github.com/PyCQA/flake8-bugbear/blob/2763a13e6d415d5a2cbda51d126f601ae8215480/bugbear.py#L1185

I think the simplest thing here is just to catch and silence any deprecation warnings that might arise as a result of this `getattr()` call. (An alternative strategy could be to hardcode a list of AST node names that we know are deprecated, and avoid passing them to the `getattr()` call. But we'd have to make sure we kept that up to date -- more AST nodes might be deprecated in future Python versions.)