### PR TITLE
Use pypa/build to build the package

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -17,17 +17,17 @@ jobs:
       with:
         python-version: 3.x
 
-    - name: Install latest pip, setuptools, twine + wheel
+    - name: Install latest pip, build & twine
       run: |
-        python -m pip install --upgrade pip setuptools twine wheel
+        python -m pip install --upgrade pip build twine
 
     - name: Build sdist + wheel
       run: |
-        python setup.py bdist_wheel
-        python setup.py sdist
+        python -m build
 
     - name: Upload to PyPI via Twine
       env:
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
+        twine check dist/*
         twine upload --verbose -u '__token__' dist/*


### PR DESCRIPTION
Closes #390 

Not sure if you wanted to do this yourself, but it's a relatively small change.
FWIW, I ran the workflow locally with `act` and it seemed fine

Cheers :)