### PR TITLE
fix name collision for node_stack on python 3.12

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -308,7 +308,6 @@ class BugBearVisitor(ast.NodeVisitor):
     filename = attr.ib()
     lines = attr.ib()
     b008_extend_immutable_calls = attr.ib(default=attr.Factory(set))
-    node_stack = attr.ib(default=attr.Factory(list))
     node_window = attr.ib(default=attr.Factory(list))
     errors = attr.ib(default=attr.Factory(list))
     futures = attr.ib(default=attr.Factory(set))


### PR DESCRIPTION
Noticed this failing in #405. I don't really understand why it's defined both as a class member and a property, but removing it has no effect as far as I can tell. I think this only fails on 3.12 and as such might be unintended upstream.