### PR TITLE
B902: Add exceptions for standard library metaclasses

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1028,7 +1028,7 @@ class BugBearVisitor(ast.NodeVisitor):
             return
 
         bases = {b.id for b in cls.bases if isinstance(b, ast.Name)}
-        if "type" in bases:
+        if any(basetype in bases for basetype in ("type", "ABCMeta", "EnumMeta")):
             if is_classmethod(decorators):
                 expected_first_args = B902.metacls
                 kind = "metaclass class"

--- a/tests/b024.py
+++ b/tests/b024.py
@@ -92,7 +92,7 @@ class multi_super_2(notabc.ABC, metaclass=abc.ABCMeta):  # safe
 
 
 class non_keyword_abcmeta_1(ABCMeta):  # safe
-    def method(self):
+    def method(cls):
         foo()
 
 


### PR DESCRIPTION
I faced a false positive when deriving my metaclass from ABCMeta, which should be fixed with this commit. I also added EnumMeta to this list, because it was the only other public metaclass in the standard library.