### PR TITLE
#418: Modify B017 to no longer have a false negative when raises() is imported directly from pytest

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -654,25 +654,28 @@ class BugBearVisitor(ast.NodeVisitor):
         lookup.
         """
         item = node.items[0]
-        item_context = item.context_expr
-
-        if (isinstance(item_context.func, ast.Name)
-            and item_context.func.id == "raises"#:  # ast.Name element with id = raises implies a call to a "raises" method
-            and isinstance(item_context.func.ctx, ast.Load)#):  # the "type" of the ast.Name object is a Load() object
-            and "pytest.raises" in self._b005_imports):
-                print('pytest.raises has been used')
-                    
+        item_context = item.context_expr                    
 
         if (
             hasattr(item_context, "func")
-            and isinstance(item_context.func, ast.Attribute)
             and (
-                item_context.func.attr == "assertRaises"
+                (
+                    isinstance(item_context.func, ast.Attribute)
+                    and (
+                        item_context.func.attr == "assertRaises"
+                        or (
+                            item_context.func.attr == "raises"
+                            and isinstance(item_context.func.value, ast.Name)
+                            and item_context.func.value.id == "pytest"
+                            and "match" not in [kwd.arg for kwd in item_context.keywords]
+                        )
+                    )
+                )
                 or (
-                    item_context.func.attr == "raises"
-                    and isinstance(item_context.func.value, ast.Name)
-                    and item_context.func.value.id == "pytest"
-                    and "match" not in [kwd.arg for kwd in item_context.keywords]
+                    isinstance(item_context.func, ast.Name)
+                    and item_context.func.id == "raises"
+                    and isinstance(item_context.func.ctx, ast.Load)
+                    and "pytest.raises" in self._b005_imports
                 )
             )
             and len(item_context.args) == 1

--- a/bugbear.py
+++ b/bugbear.py
@@ -560,7 +560,7 @@ class BugBearVisitor(ast.NodeVisitor):
                 self._b005_imports.add(name.asname or name.name)
         elif isinstance(node, ast.ImportFrom):
             for name in node.names:
-                self._b005_imports.add(f'{node.module}.{name.name or name.asname}')
+                self._b005_imports.add(f"{node.module}.{name.name or name.asname}")
         elif isinstance(node, ast.Call):
             if node.func.attr not in B005.methods:
                 return  # method name doesn't match
@@ -667,7 +667,8 @@ class BugBearVisitor(ast.NodeVisitor):
                             item_context.func.attr == "raises"
                             and isinstance(item_context.func.value, ast.Name)
                             and item_context.func.value.id == "pytest"
-                            and "match" not in [kwd.arg for kwd in item_context.keywords]
+                            and "match"
+                            not in [kwd.arg for kwd in item_context.keywords]
                         )
                     )
                 )

--- a/bugbear.py
+++ b/bugbear.py
@@ -547,7 +547,7 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b005(node)
         self.generic_visit(node)
 
-    def visit_ImportFrom(self,node):
+    def visit_ImportFrom(self, node):
         self.visit_Import(node)
 
     def visit_Set(self, node):
@@ -654,7 +654,7 @@ class BugBearVisitor(ast.NodeVisitor):
         lookup.
         """
         item = node.items[0]
-        item_context = item.context_expr                    
+        item_context = item.context_expr
 
         if (
             hasattr(item_context, "func")
@@ -676,6 +676,7 @@ class BugBearVisitor(ast.NodeVisitor):
                     and item_context.func.id == "raises"
                     and isinstance(item_context.func.ctx, ast.Load)
                     and "pytest.raises" in self._b005_imports
+                    and "match" not in [kwd.arg for kwd in item_context.keywords]
                 )
             )
             and len(item_context.args) == 1

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -7,6 +7,7 @@ import asyncio
 import unittest
 
 import pytest
+from pytest import raises
 
 CONSTANT = True
 
@@ -28,31 +29,42 @@ class Foobar(unittest.TestCase):
             raise Exception("Evil I say!")
         with pytest.raises(Exception):
             raise Exception("Evil I say!")
+        with raises(Exception):
+            raise Exception("Evil I say!")
         # These are evil as well but we are only testing inside a with statement
         self.assertRaises(Exception, lambda x, y: x / y, 1, y=0)
         pytest.raises(Exception, lambda x, y: x / y, 1, y=0)
+        raises(Exception, lambda x, y: x / y, 1, y=0)
 
     def context_manager_raises(self) -> None:
         with self.assertRaises(Exception) as ex:
             raise Exception("Context manager is good")
         with pytest.raises(Exception) as pyt_ex:
             raise Exception("Context manager is good")
+        with raises(Exception) as r_ex:
+            raise Exception("Context manager is good")
 
         self.assertEqual("Context manager is good", str(ex.exception))
         self.assertEqual("Context manager is good", str(pyt_ex.value))
+        self.assertEqual("Context manager is good", str(r_ex.value))
 
     def regex_raises(self) -> None:
         with self.assertRaisesRegex(Exception, "Regex is good"):
             raise Exception("Regex is good")
         with pytest.raises(Exception, match="Regex is good"):
             raise Exception("Regex is good")
+        with raises(Exception, match="Regex is good"):
+            raise Exception("Regex is good")
 
     def non_context_manager_raises(self) -> None:
         self.assertRaises(ZeroDivisionError, lambda x, y: x / y, 1, y=0)
         pytest.raises(ZeroDivisionError, lambda x, y: x / y, 1, y=0)
+        raises(ZeroDivisionError, lambda x, y: x / y, 1, y=0)
 
     def raises_with_absolute_reference(self):
         with self.assertRaises(asyncio.CancelledError):
             Foo()
         with pytest.raises(asyncio.CancelledError):
+            Foo()
+        with raises(asyncio.CancelledError):
             Foo()

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -534,7 +534,7 @@ class BugbearTestCase(unittest.TestCase):
             B908(37, 0),
             B908(41, 0),
             B908(45, 0),
-            B017(56, 0)
+            B017(56, 0),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -258,7 +258,7 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(25, 8), B017(27, 8), B017(29, 8))
+        expected = self.errors(B017(26, 8), B017(28, 8), B017(30, 8), B017(32, 8))
         self.assertEqual(errors, expected)
 
     def test_b018_functions(self):
@@ -530,9 +530,11 @@ class BugbearTestCase(unittest.TestCase):
             B908(15, 8),
             B908(21, 8),
             B908(27, 8),
+            B017(37, 0),
             B908(37, 0),
             B908(41, 0),
             B908(45, 0),
+            B017(56, 0)
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Logic for check B017 has been updated to check for cases where `with raises()` is used when `raises` is imported using an `ast.ImportFrom` node (that is, `from pytest import raises`) rather than an `ast.Import` node, which the current logic handles.

This has included some updates for check B005 to ensure `ast.ImportFrom` nodes are added to the "imports" set maintained in the `BugBearVisitor` class.

Tests have been updated to check that this code pattern is now flagged with B017 and tox tests have passed for Python 3.11 (which is what I have installed).

Fixes #418. 