### PR TITLE
Add flake8 to pre-commit checks, with local bugbear as a plug-in

### DIFF
--- a/.flake8-pre-commit.cfg
+++ b/.flake8-pre-commit.cfg
@@ -1,0 +1,7 @@
+# Additional flake8 config which allows the pre-commit flake8 installation to
+# use our local plugin as-is.
+[flake8:local-plugins]
+extension =
+  MC1 = bugbear:BugBearChecker
+paths =
+  .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,11 @@ repos:
       - id: black
         args:
         - --preview
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+    - id: flake8
+      args: [--append-config=.flake8-pre-commit.cfg]
+      additional_dependencies: [attrs>=19.2.0]
+      exclude: ^tests\/


### PR DESCRIPTION
For https://github.com/PyCQA/flake8-bugbear/issues/412

Considered doing this as a [repo local-hook](https://pre-commit.com/#repository-local-hooks) but it would require somehow hardcoding the venv location.

Implemented using pre-commit instance of flake8, and passing some additional config (and attr dependency) so that it can use the live bugbear.py from the repo.

This had to be split out to a separate config, because if it was in the base one, it would break local venv usage of flake8 because there would be duplicate bugbear plugins.