### PR TITLE
update black version, and exclude the tests/b*** files from formatting checks so they don't break tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,12 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+        exclude: ^tests/b.*
 
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
       - id: black
         args:
         - --preview
+        exclude: ^tests/b.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        exclude: ^tests/b.*
 
   - repo: https://github.com/psf/black
     rev: 23.11.0
@@ -14,4 +13,3 @@ repos:
       - id: black
         args:
         - --preview
-        exclude: ^tests/b.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,10 @@ version = {attr = "bugbear.__version__"}
 
 [tool.isort]
 profile = "black"
+
+[tool.black]
+force-exclude = '''
+(
+  ^/tests\/b.*
+)
+'''


### PR DESCRIPTION
Fix to prevent pre-commit ci autoupdate from breaking tests by reformatting test-code and changing line nums. Example: https://github.com/PyCQA/flake8-bugbear/pull/422/files