### PR TITLE
add flake8 python version check script and CI check

### DIFF
--- a/.github/workflows/flake8_py_version_check.yml
+++ b/.github/workflows/flake8_py_version_check.yml
@@ -9,5 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
+        allow-prereleases: true
     - name: run script
       run: python scripts/flake8_py_version_check.py

--- a/.github/workflows/flake8_py_version_check.yml
+++ b/.github/workflows/flake8_py_version_check.yml
@@ -1,0 +1,13 @@
+name: flake8_py_version_check
+on:
+  workflow_dispatch: {}
+  schedule:
+  # every Sunday at midnight
+  - cron: "0 0 * * 0"
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: run script
+      run: python scripts/flake8_py_version_check.py

--- a/scripts/flake8_py_version_check.py
+++ b/scripts/flake8_py_version_check.py
@@ -15,7 +15,8 @@ def main():
 
     # get pypi data for flake8 as json
     curl_output = subprocess.getoutput(
-        "curl -L -s --header 'Accept: application/vnd.pypi.simple.v1+json' https://pypi.org/simple/flake8"
+        "curl -L -s --header 'Accept: application/vnd.pypi.simple.v1+json'"
+        " https://pypi.org/simple/flake8"
     )
     flake8_pypi_data = json.loads(curl_output)
 
@@ -25,9 +26,10 @@ def main():
     )
     flake8_requires = latest_file_data["requires-python"]
 
-    assert (
-        flake8_requires == flake8_bugbear_requires
-    ), f"python version requirements don't match: ({flake8_requires=} != {flake8_bugbear_requires=})"
+    assert flake8_requires == flake8_bugbear_requires, (
+        f"python version requirements don't match: ({flake8_requires=} !="
+        f" {flake8_bugbear_requires=})"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/flake8_py_version_check.py
+++ b/scripts/flake8_py_version_check.py
@@ -1,0 +1,34 @@
+import json
+import re
+import subprocess
+
+
+def main():
+    # find a line in pyproject.toml that looks like `python-requires = "..."`
+    # with forgiving spacing and single or double quotes
+    with open("pyproject.toml") as fp:
+        pyproject_txt = fp.read()
+    match = re.search(r"""\n\s*requires-python\s*=\s*['"](.*)['"]""", pyproject_txt)
+    assert match is not None, "'requires-python' line not found in pyproject.toml"
+
+    flake8_bugbear_requires = match.group(1).strip()
+
+    # get pypi data for flake8 as json
+    curl_output = subprocess.getoutput(
+        "curl -L -s --header 'Accept: application/vnd.pypi.simple.v1+json' https://pypi.org/simple/flake8"
+    )
+    flake8_pypi_data = json.loads(curl_output)
+
+    # find latest non-yanked flake8 file data
+    latest_file_data = next(
+        file for file in reversed(flake8_pypi_data["files"]) if not file["yanked"]
+    )
+    flake8_requires = latest_file_data["requires-python"]
+
+    assert (
+        flake8_requires == flake8_bugbear_requires
+    ), f"python version requirements don't match: ({flake8_requires=} != {flake8_bugbear_requires=})"
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/flake8_py_version_check.py
+++ b/scripts/flake8_py_version_check.py
@@ -1,21 +1,16 @@
 import json
-import re
 import subprocess
+import tomllib
 
 
 def main():
-    # find a line in pyproject.toml that looks like `python-requires = "..."`
-    # with forgiving spacing and single or double quotes
-    with open("pyproject.toml") as fp:
-        pyproject_txt = fp.read()
-    match = re.search(r"""\n\s*requires-python\s*=\s*['"](.*)['"]""", pyproject_txt)
-    assert match is not None, "'requires-python' line not found in pyproject.toml"
-
-    flake8_bugbear_requires = match.group(1).strip()
+    with open("pyproject.toml", "rb") as fp:
+        toml_data = tomllib.load(fp)
+        flake8_bugbear_requires = toml_data["project"]["requires-python"]
 
     # get pypi data for flake8 as json
     curl_output = subprocess.getoutput(
-        "curl -L -s --header 'Accept: application/vnd.pypi.simple.v1+json'"
+        "curl -L -s --header 'Accept: application/vnd.pypi.simple.latest+json'"
         " https://pypi.org/simple/flake8"
     )
     flake8_pypi_data = json.loads(curl_output)


### PR DESCRIPTION
from https://github.com/PyCQA/flake8-bugbear/issues/365

Made a quick standalone python script. Uses curl (so no need to pip install requests or anything else) to get pypy json info for flake8. Grabs the `requires-python = ...` line from pyproject.toml and compares the two, will throw an error if they don't match. 

Note - chose to get bugbear version from pyproject.toml rather than fetching bugbear json because then the test would fail until a bugbear update was uploaded to pypi.

Not sure about naming or folder placement - just stuck it in a `scripts` folder.

Testing:

Made it run on push, and changed the python version in pyproject.toml to see it fail. [Sample error output](https://github.com/r-downing/flake8-bugbear/actions/runs/7041812391/job/19164955564)

<details><summary>error output:</summary>

```
Run python scripts/flake8_py_version_check.py
Traceback (most recent call last):
  File "/home/runner/work/flake8-bugbear/flake8-bugbear/scripts/flake8_py_version_check.py", line 3[4](https://github.com/r-downing/flake8-bugbear/actions/runs/7041812391/job/19164955564#step:3:5), in <module>
    main()
  File "/home/runner/work/flake[8](https://github.com/r-downing/flake8-bugbear/actions/runs/7041812391/job/19164955564#step:3:9)-bugbear/flake8-bugbear/scripts/flake8_py_version_check.py", line 2[9](https://github.com/r-downing/flake8-bugbear/actions/runs/7041812391/job/19164955564#step:3:10), in main
    flake8_requires == flake8_bugbear_requires
AssertionError: python version requirements don't match: (flake8_requires='>=3.8.1' != flake8_bugbear_requires='>=3.8.0')
```

</details>

Fixes #365 