### PR TITLE
add classname to b018 useless-expression output

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1182,7 +1182,13 @@ class BugBearVisitor(ast.NodeVisitor):
                     or subnode.value.value is None
                 )
             ):
-                self.errors.append(B018(subnode.lineno, subnode.col_offset))
+                self.errors.append(
+                    B018(
+                        subnode.lineno,
+                        subnode.col_offset,
+                        vars=(subnode.value.__class__.__name__,),
+                    )
+                )
 
     def check_for_b021(self, node):
         if (
@@ -1835,7 +1841,7 @@ B017 = Error(
 )
 B018 = Error(
     message=(
-        "B018 Found useless expression. Consider either assigning it to a "
+        "B018 Found useless {} expression. Consider either assigning it to a "
         "variable or removing it."
     )
 )

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -267,11 +267,23 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
 
-        expected = [B018(line, 4) for line in range(15, 25)]
-        expected.append(B018(28, 4))
-        expected.append(B018(31, 4))
-        expected.append(B018(32, 4))
-        expected.append(B018(33, 4))
+        expected = [
+            B018(15, 4, vars=("Constant",)),
+            B018(16, 4, vars=("Constant",)),
+            B018(17, 4, vars=("Constant",)),
+            B018(18, 4, vars=("Constant",)),
+            B018(19, 4, vars=("Constant",)),
+            B018(20, 4, vars=("Constant",)),
+            B018(21, 4, vars=("Constant",)),
+            B018(22, 4, vars=("List",)),
+            B018(23, 4, vars=("Set",)),
+            B018(24, 4, vars=("Dict",)),
+            B018(28, 4, vars=("Constant",)),
+            B018(31, 4, vars=("Constant",)),
+            B018(32, 4, vars=("Tuple",)),
+            B018(33, 4, vars=("Tuple",)),
+        ]
+
         self.assertEqual(errors, self.errors(*expected))
 
     def test_b018_classes(self):
@@ -279,11 +291,23 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
 
-        expected = [B018(line, 4) for line in range(16, 26)]
-        expected.append(B018(29, 4))
-        expected.append(B018(32, 4))
-        expected.append(B018(33, 4))
-        expected.append(B018(34, 4))
+        expected = [
+            B018(16, 4, vars=("Constant",)),
+            B018(17, 4, vars=("Constant",)),
+            B018(18, 4, vars=("Constant",)),
+            B018(19, 4, vars=("Constant",)),
+            B018(20, 4, vars=("Constant",)),
+            B018(21, 4, vars=("Constant",)),
+            B018(22, 4, vars=("Constant",)),
+            B018(23, 4, vars=("List",)),
+            B018(24, 4, vars=("Set",)),
+            B018(25, 4, vars=("Dict",)),
+            B018(29, 4, vars=("Constant",)),
+            B018(32, 4, vars=("Constant",)),
+            B018(33, 4, vars=("Tuple",)),
+            B018(34, 4, vars=("Tuple",)),
+        ]
+
         self.assertEqual(errors, self.errors(*expected))
 
     def test_b018_modules(self):
@@ -291,7 +315,20 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
 
-        expected = [B018(line, 0) for line in range(9, 21)]
+        expected = [
+            B018(9, 0, vars=("Constant",)),
+            B018(10, 0, vars=("Constant",)),
+            B018(11, 0, vars=("Constant",)),
+            B018(12, 0, vars=("Constant",)),
+            B018(13, 0, vars=("Constant",)),
+            B018(14, 0, vars=("Constant",)),
+            B018(15, 0, vars=("Constant",)),
+            B018(16, 0, vars=("List",)),
+            B018(17, 0, vars=("Set",)),
+            B018(18, 0, vars=("Dict",)),
+            B018(19, 0, vars=("Tuple",)),
+            B018(20, 0, vars=("Tuple",)),
+        ]
         self.assertEqual(errors, self.errors(*expected))
 
     def test_b019(self):


### PR DESCRIPTION
Had another idea for an enhancement to the B018 warning, which might make things clearer, especially for the case of tuples. This adds the AST class name to the output. 

test file:
![image](https://github.com/PyCQA/flake8-bugbear/assets/26515643/c8a98f36-06c6-4f1c-b56b-fff9c1a110a8)

before and after:
![image](https://github.com/PyCQA/flake8-bugbear/assets/26515643/ad3449d1-e2d2-4c56-90b9-24c4ff9e0eb6)
