### PR TITLE
B018 to detect useless-statements at all levels

### DIFF
--- a/tests/b018_nested.py
+++ b/tests/b018_nested.py
@@ -1,0 +1,44 @@
+
+X = 1
+False  # bad
+
+
+def func(y):
+    a = y + 1
+    5.5  # bad
+    return a
+
+
+class TestClass:
+    GOOD = [1, 3]
+    [5, 6]  # bad
+
+    def method(self, xx, yy=5):
+        t = (xx,)
+        (yy,)  # bad
+
+        while 1:
+            i = 3
+            4  # bad
+            for n in range(i):
+                j = 5
+                1.5  # bad
+                if j < n:
+                    u = {1, 2}
+                    {4, 5}  # bad
+                elif j == n:
+                    u = {1, 2, 3}
+                    {4, 5, 6}  # bad
+                else:
+                    u = {2, 3}
+                    {4, 6}  # bad
+                    try:
+                        1j  # bad
+                        r = 2j
+                    except Exception:
+                        r = 3j
+                        5  # bad
+                    finally:
+                        4j  # bad
+                        r += 1
+                    return u + t

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -331,6 +331,27 @@ class BugbearTestCase(unittest.TestCase):
         ]
         self.assertEqual(errors, self.errors(*expected))
 
+    def test_b018_nested(self):
+        filename = Path(__file__).absolute().parent / "b018_nested.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+
+        expected = [
+            B018(3, 0, vars=("Constant",)),
+            B018(8, 4, vars=("Constant",)),
+            B018(14, 4, vars=("List",)),
+            B018(18, 8, vars=("Tuple",)),
+            B018(22, 12, vars=("Constant",)),
+            B018(25, 16, vars=("Constant",)),
+            B018(28, 20, vars=("Set",)),
+            B018(31, 20, vars=("Set",)),
+            B018(34, 20, vars=("Set",)),
+            B018(36, 24, vars=("Constant",)),
+            B018(40, 24, vars=("Constant",)),
+            B018(42, 24, vars=("Constant",)),
+        ]
+        self.assertEqual(errors, self.errors(*expected))
+
     def test_b019(self):
         filename = Path(__file__).absolute().parent / "b019.py"
         bbc = BugBearChecker(filename=str(filename))


### PR DESCRIPTION
The B018 useless-statement checker was only running at the top level of modules, classes, and functions. This meant that it wouldn't detect things inside any nested blocks - e.g. `if`, `for`, `while`, `try`, etc. Did a minor refactor to make the checker run during the basic visit function so it hits things in all scopes.

Example. See added test file for more

```python
[1, 2, 3]  # useless list - would catch this

if x:
    [1, 2, 3]  # useless list - would not catch this
```
