### PR TITLE
Implement B036 check for `except BaseException` without re-raising

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,6 +195,8 @@ second usage. Save the result to a list if the result is needed multiple times.
 
 **B035**: Found dict comprehension with a static key - either a constant value or variable not from the comprehension expression. This will result in a dict with a single key that was repeatedly overwritten.
 
+**B036**: Found ``except BaseException:`` without re-raising (no ``raise`` in the top-level of the ``except`` block). This catches all kinds of things (Exception, SystemExit, KeyboardInterrupt...) and may prevent a program from exiting as expected.
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -408,7 +408,8 @@ class BugBearVisitor(ast.NodeVisitor):
             if maybe_error is not None:
                 self.errors.append(maybe_error)
         if "BaseException" in names and not any(
-            isinstance(subnode, ast.Raise) and subnode.exc is None
+            isinstance(subnode, ast.Raise)
+            and (subnode.exc is None or subnode.exc.id == node.name)
             for subnode in node.body
         ):
             self.errors.append(B036(node.lineno, node.col_offset))
@@ -1677,8 +1678,8 @@ B001 = Error(
     message=(
         "B001 Do not use bare `except:`, it also catches unexpected "
         "events like memory errors, interrupts, system exit, and so on.  "
-        "Prefer `except Exception:`.  If you're sure what you're doing, "
-        "be explicit and write `except BaseException:`."
+        "Prefer excepting specific exceptions  If you're sure what you're "
+        "doing, be explicit and write `except BaseException:`."
     )
 )
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -324,6 +324,31 @@ def _typesafe_issubclass(cls, class_or_tuple):
         return False
 
 
+class ExceptBaseExceptionVisitor(ast.NodeVisitor):
+    def __init__(self, except_node: ast.ExceptHandler) -> None:
+        super().__init__()
+        self.root = except_node
+        self._re_raised = False
+
+    def re_raised(self) -> bool:
+        self.visit(self.root)
+        return self._re_raised
+
+    def visit_Raise(self, node: ast.Raise):
+        """If we find a corresponding `raise` or `raise e` where e was from
+        `except BaseException as e:` then we mark re_raised as True and can
+        stop scanning."""
+        if node.exc is None or node.exc.id == self.root.name:
+            self._re_raised = True
+            return
+        return super().generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler):
+        if node is not self.root:
+            return  # entered a nested except - stop searching
+        return super().generic_visit(node)
+
+
 @attr.s
 class BugBearVisitor(ast.NodeVisitor):
     filename = attr.ib()
@@ -407,10 +432,9 @@ class BugBearVisitor(ast.NodeVisitor):
             maybe_error = _check_redundant_excepthandlers(names, node)
             if maybe_error is not None:
                 self.errors.append(maybe_error)
-        if "BaseException" in names and not any(
-            isinstance(subnode, ast.Raise)
-            and (subnode.exc is None or subnode.exc.id == node.name)
-            for subnode in node.body
+        if (
+            "BaseException" in names
+            and not ExceptBaseExceptionVisitor(node).re_raised()
         ):
             self.errors.append(B036(node.lineno, node.col_offset))
 

--- a/tests/b001.py
+++ b/tests/b001.py
@@ -23,13 +23,13 @@ except (KeyError, IndexError):
 
 try:
     pass
-except BaseException as be:
+except ValueError as be:
     # no warning here, all good
     pass
 
 try:
     pass
-except BaseException:
+except IndexError:
     # no warning here, all good
     pass
 

--- a/tests/b014.py
+++ b/tests/b014.py
@@ -41,7 +41,7 @@ try:
     pass
 except (MyError, BaseException) as e:
     # But we *can* assume that everything is a subclass of BaseException
-    pass
+    raise e
 
 
 try:

--- a/tests/b036.py
+++ b/tests/b036.py
@@ -1,0 +1,35 @@
+
+try:
+    pass
+except BaseException:  # bad
+    print("aaa")
+    pass
+
+
+try:
+    pass
+except BaseException as ex:  # bad
+    print(ex)
+    pass
+
+
+try:
+    pass
+except ValueError:
+    raise
+except BaseException:  # bad
+    pass
+
+
+try:
+    pass
+except BaseException:  # ok - reraised
+    print("aaa")
+    raise
+
+
+try:
+    pass
+except BaseException as ex:  # bad - raised something else
+    print("aaa")
+    raise KeyError from ex

--- a/tests/b036.py
+++ b/tests/b036.py
@@ -33,3 +33,8 @@ try:
 except BaseException as ex:  # bad - raised something else
     print("aaa")
     raise KeyError from ex
+
+try:
+    pass
+except BaseException as e:
+    raise e  # ok - raising same thing

--- a/tests/b036.py
+++ b/tests/b036.py
@@ -38,3 +38,17 @@ try:
     pass
 except BaseException as e:
     raise e  # ok - raising same thing
+
+try:
+    pass
+except BaseException:
+    if 0:
+        raise  # ok - raised somewhere within branch
+
+try:
+    pass
+except BaseException:
+    try:  # nested try
+        pass
+    except ValueError:
+        raise  # bad - raising within a nested try/except, but not within the main one

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -607,6 +607,7 @@ class BugbearTestCase(unittest.TestCase):
             B036(11, 0),
             B036(20, 0),
             B036(33, 0),
+            B036(50, 0),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -44,6 +44,7 @@ from bugbear import (
     B033,
     B034,
     B035,
+    B036,
     B901,
     B902,
     B903,
@@ -594,6 +595,18 @@ class BugbearTestCase(unittest.TestCase):
             B035(19, 12, vars=("a",)),
             B035(25, 21, vars=("CONST_KEY_VAR",)),
             B035(35, 33, vars=("v3",)),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b036(self) -> None:
+        filename = Path(__file__).absolute().parent / "b036.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B036(4, 0),
+            B036(11, 0),
+            B036(20, 0),
+            B036(33, 0),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Started implementing this new check per https://github.com/PyCQA/flake8-bugbear/issues/174

Currently just looking for `BaseException` - I figured `Exception` should maybe be a separate, optional one.

It only checks for re-raises at the top-level of the except. I thought maybe checking all branches of of a complex `except` block to see they all re-raise might be overkill - WDYT?

This does contradict the advice (and failing test-cases) of B001:
> Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.  Prefer `except Exception:`.  If you're sure what you're doing, be explicit and write `except BaseException:`.Flake8(B001)

So those would also need to be updated, and should probably change that wording - what do you think should be suggested instead? Or just "use a more specific exception" or something like that?