### PR TITLE
make B017 also apply to BaseException

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -682,7 +682,7 @@ class BugBearVisitor(ast.NodeVisitor):
             )
             and len(item_context.args) == 1
             and isinstance(item_context.args[0], ast.Name)
-            and item_context.args[0].id == "Exception"
+            and item_context.args[0].id in {"Exception", "BaseException"}
             and not item.optional_vars
         ):
             self.errors.append(B017(node.lineno, node.col_offset))

--- a/tests/b017.py
+++ b/tests/b017.py
@@ -1,6 +1,6 @@
 """
 Should emit:
-B017 - on lines 24, 26, 28, 31 and 32.
+B017 - on lines 24, 26, 28, 31, 32, 73, 75, 77.
 """
 
 import asyncio
@@ -67,4 +67,12 @@ class Foobar(unittest.TestCase):
         with pytest.raises(asyncio.CancelledError):
             Foo()
         with raises(asyncio.CancelledError):
+            Foo()
+
+    def raises_base_exception(self):
+        with self.assertRaises(BaseException):
+            Foo()
+        with pytest.raises(BaseException):
+            Foo()
+        with raises(BaseException):
             Foo()

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -259,7 +259,15 @@ class BugbearTestCase(unittest.TestCase):
         filename = Path(__file__).absolute().parent / "b017.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
-        expected = self.errors(B017(26, 8), B017(28, 8), B017(30, 8), B017(32, 8))
+        expected = self.errors(
+            B017(26, 8),
+            B017(28, 8),
+            B017(30, 8),
+            B017(32, 8),
+            B017(73, 8),
+            B017(75, 8),
+            B017(77, 8),
+        )
         self.assertEqual(errors, expected)
 
     def test_b018_functions(self):


### PR DESCRIPTION
on the subject of `BaseException` I thought it might make sense for this `assertRaises` check to apply to that as well