### PR TITLE
Implement B037 check for yielding or returning values in __init__()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,7 @@ second usage. Save the result to a list if the result is needed multiple times.
 
 **B036**: Found ``except BaseException:`` without re-raising (no ``raise`` in the top-level of the ``except`` block). This catches all kinds of things (Exception, SystemExit, KeyboardInterrupt...) and may prevent a program from exiting as expected.
 
+**B037**: Found ``return <value>``, ``yield``, ``yield <value>``, or ``yield from <value>`` in class ``__init__()`` method. No values should be returned or yielded, only bare ``return``s are ok.
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -351,35 +351,6 @@ class ExceptBaseExceptionVisitor(ast.NodeVisitor):
         return super().generic_visit(node)
 
 
-class ClassInitVisitor(ast.NodeVisitor):
-    """Use get_errors() to scan a ClassDef's __init__() method to ensure that
-    it doesn't have any `yield` or `return <value>`"""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.errors: list[error] = []
-
-    @staticmethod
-    def get_errors(class_node: ast.ClassDef) -> list[error] | None:
-        funcs = (n for n in class_node.body if isinstance(n, ast.FunctionDef))
-        init_func = next((n for n in funcs if n.name == "__init__"), None)
-        if init_func is None:
-            return None
-        visitor = ClassInitVisitor()
-        visitor.visit(init_func)
-        return visitor.errors
-
-    def visit_Return(self, node: ast.Return) -> None:  # noqa: B906
-        if node.value is not None:
-            self.errors.append(B037(node.lineno, node.col_offset))
-
-    def visit_Yield(self, node: ast.Yield) -> None:  # noqa: B906
-        self.errors.append(B037(node.lineno, node.col_offset))
-
-    def visit_YieldFrom(self, node: ast.YieldFrom) -> None:  # noqa: B906
-        self.errors.append(B037(node.lineno, node.col_offset))
-
-
 @attr.s
 class BugBearVisitor(ast.NodeVisitor):
     filename = attr.ib()
@@ -409,6 +380,30 @@ class BugBearVisitor(ast.NodeVisitor):
 
         context, stack = self.contexts[-1]
         return stack
+
+    def in_class_init(self) -> bool:
+        return (
+            len(self.contexts) >= 2
+            and isinstance(self.contexts[-2].node, ast.ClassDef)
+            and isinstance(self.contexts[-1].node, ast.FunctionDef)
+            and self.contexts[-1].node.name == "__init__"
+        )
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if self.in_class_init():
+            if node.value is not None:
+                self.errors.append(B037(node.lineno, node.col_offset))
+        self.generic_visit(node)
+
+    def visit_Yield(self, node: ast.Yield) -> None:
+        if self.in_class_init():
+            self.errors.append(B037(node.lineno, node.col_offset))
+        self.generic_visit(node)
+
+    def visit_YieldFrom(self, node: ast.YieldFrom) -> None:
+        if self.in_class_init():
+            self.errors.append(B037(node.lineno, node.col_offset))
+        self.generic_visit(node)
 
     def visit(self, node):
         is_contextful = isinstance(node, CONTEXTFUL_NODES)
@@ -575,8 +570,6 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b903(node)
         self.check_for_b021(node)
         self.check_for_b024_and_b027(node)
-        if init_errors := ClassInitVisitor.get_errors(node):
-            self.errors.extend(init_errors)
         self.generic_visit(node)
 
     def visit_Try(self, node):

--- a/tests/b037.py
+++ b/tests/b037.py
@@ -1,0 +1,33 @@
+
+class A:
+    def __init__(self) -> None:
+        return 1  # bad
+
+class B:
+    def __init__(self, x) -> None:
+        if x:
+            return  # ok
+        else:
+            return []  # bad
+
+    class BNested:
+        def __init__(self) -> None:
+            yield  # bad
+
+
+class C:
+    def func(self):
+        pass
+
+    def __init__(self, k="") -> None:
+        yield from []  # bad
+
+
+class D(C):
+    def __init__(self, k="") -> None:
+        super().__init__(k)
+        return None  # bad
+    
+class E:
+    def __init__(self) -> None:
+        yield "a"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -45,6 +45,7 @@ from bugbear import (
     B034,
     B035,
     B036,
+    B037,
     B901,
     B902,
     B903,
@@ -616,6 +617,20 @@ class BugbearTestCase(unittest.TestCase):
             B036(20, 0),
             B036(33, 0),
             B036(50, 0),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b037(self) -> None:
+        filename = Path(__file__).absolute().parent / "b037.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B037(4, 8),
+            B037(11, 12),
+            B037(15, 12),
+            B037(23, 8),
+            B037(29, 8),
+            B037(33, 8),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Implement check for ``return <value>``, ``yield``, ``yield <value>``, or ``yield from <value>`` in class ``__init__()`` method. No values should be returned or yielded, only bare ``return``s are ok.

These would be runtime errors, if and when these statements are reached.

This does trigger on `return None` which is equivalent to `return`, but kind of confusing and pointless to write in a function that shouldn't return anything.