### PR TITLE
refactor(b038): Cleanup unused code in B038Checker

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1623,11 +1623,6 @@ class B038Checker(ast.NodeVisitor):
 
         self.generic_visit(node)
 
-    def visit_Name(self, node: ast.Name):
-        if isinstance(node.ctx, ast.Del):
-            self.mutations.append(node)
-        self.generic_visit(node)
-
     def visit(self, node):
         """Like super-visit but supports iteration over lists."""
         if not isinstance(node, list):

--- a/tests/b038.py
+++ b/tests/b038.py
@@ -16,6 +16,7 @@ for elem in some_list:
     print(elem)
     if elem % 2 == 0:
         some_other_list.remove(elem)  # should not error
+        del some_other_list
 
 
 some_list = [1, 2, 3]

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -976,10 +976,10 @@ class BugbearTestCase(unittest.TestCase):
         print(errors)
         expected = [
             B038(11, 8),
-            B038(25, 8),
             B038(26, 8),
-            B038(40, 8),
-            B038(46, 8),
+            B038(27, 8),
+            B038(41, 8),
+            B038(47, 8),
         ]
         self.assertEqual(errors, self.errors(*expected))
 


### PR DESCRIPTION
The unused code would introduce a bug when used, thus I believe it's better to remove it.

Essentially, it would've flagged _any_ `del` statement within a loop, without check for the name. 
However, because the `B038Checker` visits `Del` nodes, and doesn't call `generic_visit` from there, we'll never reach a `Name` node that has the `ctx == Del`.

I've added a test case, just to make sure :slightly_smiling_face: 