### PR TITLE
Remove decorators named validator and root_validator from B902 checks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,7 +39,7 @@ python3 -m venv /path/to/venv
 
 ```console
 cd flake8-bugbear
-/path/to/venv/bin/pip install -e .[dev]
+/path/to/venv/bin/pip install -e '.[dev]'
 ```
 
 ## Running Tests

--- a/README.rst
+++ b/README.rst
@@ -315,7 +315,7 @@ This could be useful, when using other libraries that provide more immutable cal
 beside those already handled by ``flake8-bugbear``. Calls to these method will no longer
 raise a ``B008`` warning.
 
-``classmethod-decorators``: Specify a list of decorators to additionally mark a method as a ``classmethod`` as used by B902. Default values are ``classmethod, validator, root_validator``, and when an ``@obj.name`` decorator is specified it will match against either ``name`` or ``obj.name``.
+``classmethod-decorators``: Specify a list of decorators to additionally mark a method as a ``classmethod`` as used by B902. The default only checks for ``classmethod``. When an ``@obj.name`` decorator is specified it will match against either ``name`` or ``obj.name``.
 This functions similarly to how `pep8-naming <https://github.com/PyCQA/pep8-naming>` handles it, but with different defaults, and they don't support specifying attributes such that a decorator will never match against a specified value ``obj.name`` even if decorated with ``@obj.name``.
 
 For example::

--- a/bugbear.py
+++ b/bugbear.py
@@ -41,7 +41,7 @@ B908_unittest_methods = {
     "assertWarnsRegex",
 }
 
-B902_default_decorators = {"classmethod", "validator", "root_validator"}
+B902_default_decorators = {"classmethod"}
 
 Context = namedtuple("Context", ["node", "stack"])
 


### PR DESCRIPTION

## What
This removes methods named `validator` and `root_validator` from the B902 check

## Why
Fixes https://github.com/PyCQA/flake8-bugbear/issues/413

Removes false positives for common cases, like using attrs validators

## Testing
ran `tox` and all tests are passing