### PR TITLE
fix(b909): Fix false positive affecting containers of mutables

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1631,7 +1631,10 @@ class B909Checker(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign):
         for target in node.targets:
-            if isinstance(target, ast.Subscript) and _to_name_str(target.value):
+            if (
+                isinstance(target, ast.Subscript)
+                and _to_name_str(target.value) == self.name
+            ):
                 self.mutations[self._conditional_block].append(node)
         self.generic_visit(node)
 

--- a/tests/b909.py
+++ b/tests/b909.py
@@ -127,3 +127,7 @@ for _ in foo:
         bar.remove(1)
         break
     break
+
+lst: list[dict] = [{}, {}, {}]
+for dic in lst:
+    dic["key"] = False


### PR DESCRIPTION
The false positives occurred when trying to edit a dictionary while iterating over a list of dictionaries:

```
lst: list[dict] = [{}, {}, {}]
for dic in lst:
    dic["key"] = False # was false positive - fixed now
```