### PR TITLE
Contextvar mutable or call default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
 
         os: [ubuntu-latest]
 

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,8 @@ second usage. Save the result to a list if the result is needed multiple times.
 
 **B038**: **Moved to B909** - Found a mutation of a mutable loop iterable inside the loop body. Changes to the iterable of a loop such as calls to `list.remove()` or via `del` can cause unintended bugs.
 
+**B039**: ``ContextVar`` with mutable literal or function call as default. This is only evaluated once, and all subsequent calls to `.get()` would return the same instance of the default. This uses the same logic as B006 and B008, including ignoring values in ``extend-immutable-calls``.
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -315,7 +317,7 @@ The plugin currently has the following settings:
 ``extend-immutable-calls``: Specify a list of additional immutable calls.
 This could be useful, when using other libraries that provide more immutable calls,
 beside those already handled by ``flake8-bugbear``. Calls to these method will no longer
-raise a ``B008`` warning.
+raise a ``B008`` or ``B039`` warning.
 
 ``classmethod-decorators``: Specify a list of decorators to additionally mark a method as a ``classmethod`` as used by B902. The default only checks for ``classmethod``. When an ``@obj.name`` decorator is specified it will match against either ``name`` or ``obj.name``.
 This functions similarly to how `pep8-naming <https://github.com/PyCQA/pep8-naming>` handles it, but with different defaults, and they don't support specifying attributes such that a decorator will never match against a specified value ``obj.name`` even if decorated with ``@obj.name``.
@@ -350,6 +352,11 @@ MIT
 
 Change Log
 ----------
+
+FUTURE
+~~~~~~
+
+* Add B039, ``ContextVar`` with mutable literal or function call as default.
 
 24.4.26
 ~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -507,6 +507,7 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b026(node)
         self.check_for_b028(node)
         self.check_for_b034(node)
+        self.check_for_b039(node)
         self.check_for_b905(node)
         self.generic_visit(node)
 
@@ -655,8 +656,34 @@ class BugBearVisitor(ast.NodeVisitor):
             self.errors.append(B005(node.lineno, node.col_offset))
 
     def check_for_b006_and_b008(self, node):
-        visitor = FuntionDefDefaultsVisitor(self.b008_extend_immutable_calls)
+        visitor = FunctionDefDefaultsVisitor(
+            B006, B008, self.b008_extend_immutable_calls
+        )
         visitor.visit(node.args.defaults + node.args.kw_defaults)
+        self.errors.extend(visitor.errors)
+
+    def check_for_b039(self, node: ast.Call):
+        if not (
+            (isinstance(node.func, ast.Name) and node.func.id == "ContextVar")
+            or (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "ContextVar"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "contextvars"
+            )
+        ):
+            return
+        # ContextVar only takes one kw currently, but better safe than sorry
+        for kw in node.keywords:
+            if kw.arg == "default":
+                break
+        else:
+            return
+
+        visitor = FunctionDefDefaultsVisitor(
+            B039, B039, self.b008_extend_immutable_calls
+        )
+        visitor.visit(kw.value)
         self.errors.extend(visitor.errors)
 
     def check_for_b007(self, node):
@@ -1780,9 +1807,13 @@ class NamedExprFinder(ast.NodeVisitor):
         return node
 
 
-class FuntionDefDefaultsVisitor(ast.NodeVisitor):
-    def __init__(self, b008_extend_immutable_calls=None):
+class FunctionDefDefaultsVisitor(ast.NodeVisitor):
+    def __init__(
+        self, error_code_calls, error_code_literals, b008_extend_immutable_calls=None
+    ):
         self.b008_extend_immutable_calls = b008_extend_immutable_calls or set()
+        self.error_code_calls = error_code_calls
+        self.error_code_literals = error_code_literals
         for node in B006.mutable_literals + B006.mutable_comprehensions:
             setattr(self, f"visit_{node}", self.visit_mutable_literal_or_comprehension)
         self.errors = []
@@ -1801,14 +1832,14 @@ class FuntionDefDefaultsVisitor(ast.NodeVisitor):
         #
         # We do still search for cases of B008 within mutable structures though.
         if self.arg_depth == 1:
-            self.errors.append(B006(node.lineno, node.col_offset))
+            self.errors.append(self.error_code_calls(node.lineno, node.col_offset))
         # Check for nested functions.
         self.generic_visit(node)
 
     def visit_Call(self, node):
         call_path = ".".join(compose_call_path(node.func))
         if call_path in B006.mutable_calls:
-            self.errors.append(B006(node.lineno, node.col_offset))
+            self.errors.append(self.error_code_calls(node.lineno, node.col_offset))
             self.generic_visit(node)
             return
 
@@ -1824,9 +1855,11 @@ class FuntionDefDefaultsVisitor(ast.NodeVisitor):
                 pass
             else:
                 if math.isfinite(value):
-                    self.errors.append(B008(node.lineno, node.col_offset))
+                    self.errors.append(
+                        self.error_code_literals(node.lineno, node.col_offset)
+                    )
         else:
-            self.errors.append(B008(node.lineno, node.col_offset))
+            self.errors.append(self.error_code_literals(node.lineno, node.col_offset))
 
         # Check for nested functions.
         self.generic_visit(node)
@@ -2164,6 +2197,14 @@ B036 = Error(
 
 B037 = Error(
     message="B037 Class `__init__` methods must not return or yield and any values."
+)
+
+B039 = Error(
+    message=(
+        "B039 ContextVar with mutable literal or function call as default. "
+        "This is only evaluated once, and all subsequent calls to `.get()` "
+        "will return the same instance of the default."
+    )
 )
 
 # Warnings disabled by default.

--- a/tests/b039.py
+++ b/tests/b039.py
@@ -1,6 +1,6 @@
-from contextvars import ContextVar
 import contextvars
 import time
+from contextvars import ContextVar
 
 ContextVar("cv", default=[])  # bad
 ContextVar("cv", default=list())  # bad

--- a/tests/b039.py
+++ b/tests/b039.py
@@ -1,0 +1,17 @@
+from contextvars import ContextVar
+import contextvars
+import time
+
+ContextVar("cv", default=[])  # bad
+ContextVar("cv", default=list())  # bad
+ContextVar("cv", default=set())  # bad
+ContextVar("cv", default=time.time())  # bad (B008-like)
+contextvars.ContextVar("cv", default=[])  # bad
+
+
+# good
+ContextVar("cv", default=())
+contextvars.ContextVar("cv", default=())
+ContextVar("cv", default=tuple())
+
+# see tests/b006_b008.py for more comprehensive tests

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -46,6 +46,7 @@ from bugbear import (
     B035,
     B036,
     B037,
+    B039,
     B901,
     B902,
     B903,
@@ -633,6 +634,19 @@ class BugbearTestCase(unittest.TestCase):
             B037(23, 8),
             B037(29, 8),
             B037(33, 8),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b039(self) -> None:
+        filename = Path(__file__).absolute().parent / "b039.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B039(5, 25),
+            B039(6, 25),
+            B039(7, 25),
+            B039(8, 25),
+            B039(9, 37),
         )
         self.assertEqual(errors, expected)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # The test environment and commands
 [tox]
 # default environments to run without `-e`
-envlist = py38, py39, py310, py311, py312, pep8_naming
+envlist = py38, py39, py310, py311, py312, py313, pep8_naming
 
 [gh-actions]
 python =
@@ -10,6 +10,7 @@ python =
     3.10: py310
     3.11: py311,pep8_naming
     3.12: py312
+    3.13-dev: py313
 
 [testenv]
 description = Run coverage


### PR DESCRIPTION
fixes #475

Not the prettiest extension of `FunctionDefDefaultsVisitor`, and left e.g. `B006.mutable_literals` as bound to `B006` and the naming of `b008_extend_immutable_calls`. I'll fix those later unless we want to reuse B006/B008 for `ContextVar`s, or maybe just a couple comments saying that B039 also uses them.

Also adding 3.13 to CI to check for any problems there