### PR TITLE
add b040: exception with note added not reraised or used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -351,6 +351,10 @@ MIT
 Change Log
 ----------
 
+Future
+~~~~~~
+* Add B040: Exception with added note not reraised. (#474)
+
 24.4.26
 ~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -1115,10 +1115,6 @@ class BugBearVisitor(ast.NodeVisitor):
             for n in superwalk(node)
             if isinstance(n, ast.Name) and n.id in self.exceptions_tracked
         ):
-            if hasattr(node, "lineno"):
-                print("deleting", node.lineno)
-            else:
-                print("deleting0", node[0].lineno)
             del self.exceptions_tracked[name]
 
     def _get_assigned_names(self, loop_node):

--- a/tests/b040.py
+++ b/tests/b040.py
@@ -122,12 +122,13 @@ except Exception as e: # safe
 
 try:
     ...
-except Exception as e: # should error
+except Exception as e: # error
     e.add_note(str(e))
 
+# check nesting
 try:
     ...
-except Exception as e:  # should error
+except Exception as e:  # error
     e.add_note("")
     try:
         ...

--- a/tests/b040.py
+++ b/tests/b040.py
@@ -1,52 +1,51 @@
-def arbitrary_fun(*args, **kwargs):
-    ...
+def arbitrary_fun(*args, **kwargs): ...
 
+
+# classic case
 try:
     ...
 except Exception as e:
-    e.add_note("...") # error
+    e.add_note("...")  # error
 
 try:
     ...
-except Exception as e:  # safe (handled by most type checkers)
+except Exception as e:  # safe (other linters will catch this)
     pass
 
 try:
     ...
 except Exception as e:
     e.add_note("...")
-    raise # safe
+    raise  # safe
 
-try:
-    ...
-except Exception as e:
-    e.add_note("...")
-    raise e # safe
-
+# other exception raised
 try:
     ...
 except Exception as e:
     f = ValueError()
-    e.add_note("...") # error
+    e.add_note("...")  # error
     raise f
 
+# raised as cause
 try:
     ...
 except Exception as e:
     f = ValueError()
-    e.add_note("...") # safe
+    e.add_note("...")  # safe
     raise f from e
 
+# assigned to other variable
 try:
     ...
 except Exception as e:
-    e.add_note("...") # safe
+    e.add_note("...")  # safe
     foo = e
 
+# "used" in function call
 try:
     ...
 except Exception as e:
-    e.add_note("...") # safe
+    e.add_note("...")  # safe
     # not that printing the exception is actually using it, but we treat
     # it being used as a parameter to any function as "using" it
     print(e)
@@ -54,82 +53,59 @@ except Exception as e:
 try:
     ...
 except Exception as e:
-    e.add_note("...") # safe
+    e.add_note("...")  # safe
     list(e)
 
+# kwarg
 try:
     ...
 except Exception as e:
-    e.add_note("...") # safe
+    e.add_note("...")  # safe
     arbitrary_fun(kwarg=e)
 
+# stararg
 try:
     ...
 except Exception as e:
-    e.add_note("...") # safe
+    e.add_note("...")  # safe
     arbitrary_fun(*(e,))
 
 try:
     ...
 except Exception as e:
-    e.add_note("...") # safe
-    arbitrary_fun(**{"e":e})
+    e.add_note("...")  # safe
+    arbitrary_fun(**{"e": e})
 
 
+# multiple ExceptHandlers
 try:
     ...
 except ValueError as e:
-    e.add_note("") # error
+    e.add_note("")  # error
 except TypeError as e:
     raise e
 
+# exception variable used before `add_note`
 mylist = []
 try:
     ...
-except Exception as e:
+except Exception as e: # safe
     mylist.append(e)
     e.add_note("")
 
 
-def exc_add_note_not_in_except():
-    exc = ValueError()
-    exc.add_note("") # should maybe error?
-
+# AnnAssign
 try:
     ...
-except Exception as e:
-    e2 = ValueError()
-    e2.add_note("") # should maybe error?
-    raise e
-
-try:
-    ...
-except Exception as e:
-    e.add_note("")
-    e = ValueError()
-
-try:
-    ...
-except Exception as e: # should error, but we don't handle lambdas
-    e.add_note("")
-    f = lambda e: e
-
-try:
-    ...
-except Exception as e: # should error, but we don't handle nested functions
-    e.add_note("")
-    def habla(e):
-        raise e
-
-try:
-    ...
-except Exception as e: # safe
+except Exception as e:  # safe
     e.add_note("")
     ann_assign_target: Exception = e
 
+# special case: e is only used in the `add_note` call itself
 try:
     ...
-except Exception as e: # error
+except Exception as e:  # error
+    e.add_note(str(e))
     e.add_note(str(e))
 
 # check nesting
@@ -139,5 +115,70 @@ except Exception as e:  # error
     e.add_note("")
     try:
         ...
-    except ValueError as f:
-        pass
+    except ValueError as e:
+        raise
+
+# questionable if this should error
+try:
+    ...
+except Exception as e:
+    e.add_note("")
+    e = ValueError()
+
+# *** unhandled cases ***
+
+
+# This should ideally error
+def exc_add_note_not_in_except():
+    exc = ValueError()
+    exc.add_note("")
+
+
+# but not this
+def exc_add_note_not_in_except_safe(exc: ValueError):
+    exc.add_note("")
+
+
+# we currently only check the target of the except handler, even though this clearly
+# is hitting the same general pattern. But handling this case without a lot of false
+# alarms is very tricky without more infrastructure.
+try:
+    ...
+except Exception as e:
+    e2 = ValueError()  # should error
+    e2.add_note(str(e))
+
+
+def foo_add_note_in_excepthandler():
+    e2 = ValueError()
+    try:
+        ...
+    except Exception as e:
+        e2.add_note(str(e))  # safe
+    raise e2
+
+
+# We don't currently handle lambdas or function definitions inside the exception
+# handler. This isn't conceptually difficult, but not really worth it with current
+# infrastructure
+try:
+    ...
+except Exception as e:  # should error
+    e.add_note("")
+    f = lambda e: e
+
+try:
+    ...
+except Exception as e:  # should error
+    e.add_note("")
+
+    def habla(e):
+        raise e
+
+
+# We also don't track other variables
+try:
+    ...
+except Exception as e:
+    e3 = e
+    e3.add_note("")  # should error

--- a/tests/b040.py
+++ b/tests/b040.py
@@ -116,6 +116,13 @@ except Exception as e: # should error, but we don't handle lambdas
 
 try:
     ...
+except Exception as e: # should error, but we don't handle nested functions
+    e.add_note("")
+    def habla(e):
+        raise e
+
+try:
+    ...
 except Exception as e: # safe
     e.add_note("")
     ann_assign_target: Exception = e

--- a/tests/b040.py
+++ b/tests/b040.py
@@ -1,0 +1,135 @@
+def arbitrary_fun(*args, **kwargs):
+    ...
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # error
+
+try:
+    ...
+except Exception as e:  # safe (handled by most type checkers)
+    pass
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...")
+    raise # safe
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...")
+    raise e # safe
+
+try:
+    ...
+except Exception as e:
+    f = ValueError()
+    e.add_note("...") # error
+    raise f
+
+try:
+    ...
+except Exception as e:
+    f = ValueError()
+    e.add_note("...") # safe
+    raise f from e
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # safe
+    foo = e
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # safe
+    # not that printing the exception is actually using it, but we treat
+    # it being used as a parameter to any function as "using" it
+    print(e)
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # safe
+    list(e)
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # safe
+    arbitrary_fun(kwarg=e)
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # safe
+    arbitrary_fun(*(e,))
+
+try:
+    ...
+except Exception as e:
+    e.add_note("...") # safe
+    arbitrary_fun(**{"e":e})
+
+
+try:
+    ...
+except ValueError as e:
+    e.add_note("") # error
+except TypeError as e:
+    raise e
+
+mylist = []
+try:
+    ...
+except Exception as e:
+    mylist.append(e)
+    e.add_note("")
+
+
+def exc_add_note_not_in_except():
+    exc = ValueError()
+    exc.add_note("") # should maybe error?
+
+try:
+    ...
+except Exception as e:
+    e2 = ValueError()
+    e2.add_note("") # should maybe error?
+    raise e
+
+try:
+    ...
+except Exception as e:
+    e.add_note("")
+    e = ValueError()
+
+try:
+    ...
+except Exception as e: # should error, but we don't handle lambdas
+    e.add_note("")
+    f = lambda e: e
+
+try:
+    ...
+except Exception as e: # safe
+    e.add_note("")
+    ann_assign_target: Exception = e
+
+try:
+    ...
+except Exception as e: # should error
+    e.add_note(str(e))
+
+try:
+    ...
+except Exception as e:  # should error
+    e.add_note("")
+    try:
+        ...
+    except ValueError as f:
+        pass

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -646,8 +646,8 @@ class BugbearTestCase(unittest.TestCase):
             B040(28, 0),
             B040(81, 0),
             B040(107, 0),
-            B040(125, 0),
-            B040(131, 0),
+            B040(132, 0),
+            B040(138, 0),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -642,12 +642,12 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B040(6, 0),
-            B040(28, 0),
-            B040(81, 0),
+            B040(7, 0),
+            B040(24, 0),
+            B040(83, 0),
             B040(107, 0),
-            B040(132, 0),
-            B040(138, 0),
+            B040(114, 0),
+            B040(124, 0),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -646,6 +646,8 @@ class BugbearTestCase(unittest.TestCase):
             B040(28, 0),
             B040(81, 0),
             B040(107, 0),
+            B040(125, 0),
+            B040(131, 0),
         )
         self.assertEqual(errors, expected)
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -46,6 +46,7 @@ from bugbear import (
     B035,
     B036,
     B037,
+    B040,
     B901,
     B902,
     B903,
@@ -633,6 +634,18 @@ class BugbearTestCase(unittest.TestCase):
             B037(23, 8),
             B037(29, 8),
             B037(33, 8),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b040(self) -> None:
+        filename = Path(__file__).absolute().parent / "b040.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B040(6, 0),
+            B040(28, 0),
+            B040(81, 0),
+            B040(107, 0),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Fixes #474 

There's some alternatives when it comes to the scope of this check, namely whether these two should be caught
##### 1
```python
def foo():
  my_exc = ValueError()
  my_exc.add_note("I want to use this variable")
  # ... but then completely forgets to raise
```
I.e. arbitrary exception created anywhere, that appears to only be used for having a note added. This one gets tricky as its complexity approaches that of a type checker, which usually handles unused variables. If we assume that only exceptions will ever have a method called `add_note` we can sidestep trying to do any type inference.
Though this would hit false alarms with stuff like
```python
def my_add_note(e: Exception) -> None:
  e.add_note("foo")
```
so it probably isn't worth it.
##### 2

```python
try:
  ...
except:
  f = ValueError()
  f.add_note("")
```

This is essentially the same as the first one, except it's happening within an `except` scope and much more clearly looks like a bug.

Handling either case will require `exceptions_tracked` to be a full dict, and the logic in a bunch of places to be beefed up a bit. If we don't care to go with that, I will simplify the type (and rename it, it's an awful name atm) of `exceptions_tracked` and simplify/clean up some code handling it.

Handling the lambda case, or other functions defined inside an except handler, wouldn't be super complicated - but I don't really think it's worth even the slight complexity.