### PR TITLE
Replace hash with unsafe_hash

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -46,7 +46,7 @@ B902_default_decorators = {"classmethod"}
 Context = namedtuple("Context", ["node", "stack"])
 
 
-@attr.s(hash=False)
+@attr.s(unsafe_hash=False)
 class BugBearChecker:
     name = "flake8-bugbear"
     version = __version__


### PR DESCRIPTION
Background: https://www.attrs.org/en/stable/changelog.html#deprecations

Closes #485 

