### PR TITLE
Added new check B910 to suggest using Counter() instead of defaultdict(int)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,6 +273,8 @@ on the first line and urls or paths that are on their own line::
       "https://some-super-long-domain-name.com/with/some/very/long/paths"
   )
 
+**B910**: Use Counter() instead of defaultdict(int) to avoid excessive memory use as the default dict will record missing keys with the default value when accessed.
+
 
 How to enable opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -503,6 +503,7 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b034(node)
         self.check_for_b039(node)
         self.check_for_b905(node)
+        self.check_for_b910(node)
 
         # no need for copying, if used in nested calls it will be set to None
         current_b040_caught_exception = self.b040_caught_exception
@@ -1706,6 +1707,16 @@ class BugBearVisitor(ast.NodeVisitor):
         ):
             self.errors.append(B909(mutation.lineno, mutation.col_offset))
 
+    def check_for_b910(self, node: ast.Call) -> None:
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "defaultdict"
+            and len(node.args) > 0
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == "int"
+        ):
+            self.errors.append(B910(node.lineno, node.col_offset))
+
 
 def compose_call_path(node):
     if isinstance(node, ast.Attribute):
@@ -2380,6 +2391,9 @@ B909 = Error(
         "B909 editing a loop's mutable iterable often leads to unexpected results/bugs"
     )
 )
+B910 = Error(
+    message="B910 Use Counter() instead of defaultdict(int) to avoid excessive memory use"
+)
 B950 = Error(message="B950 line too long ({} > {} characters)")
 
 
@@ -2392,5 +2406,6 @@ disabled_by_default = [
     "B906",
     "B908",
     "B909",
+    "B910",
     "B950",
 ]

--- a/tests/b910.py
+++ b/tests/b910.py
@@ -1,0 +1,8 @@
+from collections import defaultdict
+
+a = defaultdict(int)
+b = defaultdict(float)
+c = defaultdict(bool)
+d = defaultdict(str)
+e = defaultdict()
+f = defaultdict(int)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -57,6 +57,7 @@ from bugbear import (
     B907,
     B908,
     B909,
+    B910,
     B950,
     BugBearChecker,
     BugBearVisitor,
@@ -1039,6 +1040,17 @@ class BugbearTestCase(unittest.TestCase):
             B909(104, 4),
             B909(105, 4),
             B909(125, 4),
+        ]
+        self.assertEqual(errors, self.errors(*expected))
+
+    def test_b910(self):
+        filename = Path(__file__).absolute().parent / "b910.py"
+        mock_options = Namespace(select=[], extend_select=["B910"])
+        bbc = BugBearChecker(filename=str(filename), options=mock_options)
+        errors = list(bbc.run())
+        expected = [
+            B910(3, 4),
+            B910(8, 4),
         ]
         self.assertEqual(errors, self.errors(*expected))
 


### PR DESCRIPTION
Implementing #323.

I'm not sure if the number B910 is OK, but it's just the next available number (not counting B950).