### PR TITLE
Add B041: Duplicate keys in dictionary literals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,8 @@ second usage. Save the result to a list if the result is needed multiple times.
 
 **B040**: Caught exception with call to ``add_note`` not used. Did you forget to ``raise`` it?
 
+**B041**: Repeated key in dictionary literal. The last value will override any previous values.
+
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -205,7 +205,7 @@ second usage. Save the result to a list if the result is needed multiple times.
 
 **B040**: Caught exception with call to ``add_note`` not used. Did you forget to ``raise`` it?
 
-**B041**: Repeated key in dictionary literal. The last value will override any previous values.
+**B041**: Repeated key-value pair in dictionary literal.
 
 Opinionated warnings
 ~~~~~~~~~~~~~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -649,7 +649,7 @@ class BugBearVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def check_for_b041(self, node) -> None:
-        # Complain if there are duplicate keys in a dictionary literal.
+        # Complain if there are duplicate key-value pairs in a dictionary literal.
         def convert_to_value(item):
             if isinstance(item, ast.Constant):
                 return item.value
@@ -668,9 +668,13 @@ class BugBearVisitor(ast.NodeVisitor):
         ]
         for key in duplicate_keys:
             key_indices = [i for i, i_key in enumerate(keys) if i_key == key]
-            for key_index in key_indices:
-                key_node = node.keys[key_index]
-                self.errors.append(B041(key_node.lineno, key_node.col_offset))
+            seen = set()
+            for index in key_indices:
+                value = convert_to_value(node.values[index])
+                if value in seen:
+                    key_node = node.keys[index]
+                    self.errors.append(B041(key_node.lineno, key_node.col_offset))
+                seen.add(value)
 
     def check_for_b005(self, node) -> None:
         if isinstance(node, ast.Import):
@@ -2368,8 +2372,7 @@ B040 = Error(
 
 B041 = Error(
     message=(
-        "B041 Repeated key in dictionary literal. The last value will override "
-        "any previous values."
+        "B041 Repeated key-value pair in dictionary literal."
     )
 )
 

--- a/tests/b041.py
+++ b/tests/b041.py
@@ -1,84 +1,24 @@
-# Simple case
-{'yes': 1, 'yes': 2}  # error
-
-# Duplicate keys with bytes vs unicode in Python 3
-{b'a': 1, u'a': 2}  # error
-{1: b'a', 1: u'a'}  # error
-
-# Duplicate keys with bytes vs unicode in Python 2
-{b'a': 1, u'a': 2}  # error
-
-# Duplicate values in Python 2
-{1: b'a', 1: u'a'}  # error
-
-# Multiple duplicate keys
-{'yes': 1, 'yes': 2, 'no': 2, 'no': 3}  # error
-
-# Duplicate keys in function call
-def f(thing):
-    pass
-f({'yes': 1, 'yes': 2})  # error
-
-# Duplicate keys in lambda function
-(lambda x: {(0, 1): 1, (0, 1): 2})  # error
-
-# Duplicate keys with tuples
-{(0, 1): 1, (0, 1): 2}  # error
-
-# Duplicate keys with int and float
-{1: 1, 1.0: 2}  # error
-
-# Duplicate keys with booleans
-{True: 1, True: 2}  # error
-
-# Duplicate keys with None
-{None: 1, None: 2}  # error
-
-# Duplicate keys with variables
 a = 1
-{a: 1, a: 2}  # error
+test = {'yes': 1, 'yes': 1}
+test = {'yes': 1, 'yes': 1, 'no': 2, 'no': 2}
+test = {'yes': 1, 'yes': 1, 'yes': 1}
+test = {1: 1, 1.0: 1}
+test = {True: 1, True: 1}
+test = {None: 1, None: 1}
+test = {a: a, a: a}
 
-# Duplicate values with variables
-a = 1
-b = 2
-{1: a, 1: b}  # error
-
-# Duplicate values with same variable value
-a = 1
+# no error if either keys or values are different
+test = {'yes': 1, 'yes': 2}
+test = {1: 1, 2: 1}
+test = {(0, 1): 1, (0, 2): 1}
+test = {(0, 1): 1, (0, 1): 2}
 b = 1
-{1: a, 1: b}  # error
-
-# Duplicate keys with same values
-{'yes': 1, 'yes': 1}  # error
-
-# Non-duplicate keys
-{'yes': 1, 'no': 2}  # safe
-
-# Non-duplicate keys with tuples having the same first element
-{(0, 1): 1, (0, 2): 1}  # safe
-
-# Non-duplicate keys in function call
-def test_func(thing):
-    pass
-test_func({True: 1, None: 2, False: 1})  # safe
-
-# Non-duplicate keys with bool and None
-{True: 1, None: 2, False: 1}  # safe
-
-# Non-duplicate keys with different ints
-{1: 1, 2: 1}  # safe
-
-# Duplicate keys with differently-named variables
-test = 'yes'
-rest = 'yes'
-{test: 1, rest: 2}  # safe
-
-# Non-duplicate tuple keys
-{(0, 1): 1, (0, 2): 1}  # safe
-
-# Duplicate keys with instance attributes
+test = {a: a, b: a}
+test = {a: a, a: b}
 class TestClass:
     pass
 f = TestClass()
 f.a = 1
-{f.a: 1, f.a: 1}  # safe
+test = {f.a: 1, f.a: 1}
+
+

--- a/tests/b041.py
+++ b/tests/b041.py
@@ -1,0 +1,84 @@
+# Simple case
+{'yes': 1, 'yes': 2}  # error
+
+# Duplicate keys with bytes vs unicode in Python 3
+{b'a': 1, u'a': 2}  # error
+{1: b'a', 1: u'a'}  # error
+
+# Duplicate keys with bytes vs unicode in Python 2
+{b'a': 1, u'a': 2}  # error
+
+# Duplicate values in Python 2
+{1: b'a', 1: u'a'}  # error
+
+# Multiple duplicate keys
+{'yes': 1, 'yes': 2, 'no': 2, 'no': 3}  # error
+
+# Duplicate keys in function call
+def f(thing):
+    pass
+f({'yes': 1, 'yes': 2})  # error
+
+# Duplicate keys in lambda function
+(lambda x: {(0, 1): 1, (0, 1): 2})  # error
+
+# Duplicate keys with tuples
+{(0, 1): 1, (0, 1): 2}  # error
+
+# Duplicate keys with int and float
+{1: 1, 1.0: 2}  # error
+
+# Duplicate keys with booleans
+{True: 1, True: 2}  # error
+
+# Duplicate keys with None
+{None: 1, None: 2}  # error
+
+# Duplicate keys with variables
+a = 1
+{a: 1, a: 2}  # error
+
+# Duplicate values with variables
+a = 1
+b = 2
+{1: a, 1: b}  # error
+
+# Duplicate values with same variable value
+a = 1
+b = 1
+{1: a, 1: b}  # error
+
+# Duplicate keys with same values
+{'yes': 1, 'yes': 1}  # error
+
+# Non-duplicate keys
+{'yes': 1, 'no': 2}  # safe
+
+# Non-duplicate keys with tuples having the same first element
+{(0, 1): 1, (0, 2): 1}  # safe
+
+# Non-duplicate keys in function call
+def test_func(thing):
+    pass
+test_func({True: 1, None: 2, False: 1})  # safe
+
+# Non-duplicate keys with bool and None
+{True: 1, None: 2, False: 1}  # safe
+
+# Non-duplicate keys with different ints
+{1: 1, 2: 1}  # safe
+
+# Duplicate keys with differently-named variables
+test = 'yes'
+rest = 'yes'
+{test: 1, rest: 2}  # safe
+
+# Non-duplicate tuple keys
+{(0, 1): 1, (0, 2): 1}  # safe
+
+# Duplicate keys with instance attributes
+class TestClass:
+    pass
+f = TestClass()
+f.a = 1
+{f.a: 1, f.a: 1}  # safe

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -48,6 +48,7 @@ from bugbear import (
     B037,
     B039,
     B040,
+    B041,
     B901,
     B902,
     B903,
@@ -663,6 +664,23 @@ class BugbearTestCase(unittest.TestCase):
             B040(107, 0),
             B040(114, 0),
             B040(124, 0),
+        )
+        self.assertEqual(errors, expected)
+
+    def test_b041(self) -> None:
+        filename = Path(__file__).absolute().parent / "b041.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B041(2, 18),
+            B041(3, 18),
+            B041(3, 37),
+            B041(4, 18),
+            B041(4, 28),
+            B041(5, 14),
+            B041(6, 17),
+            B041(7, 17),
+            B041(8, 14),
         )
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
This is the counterpart to the duplicate dictionary key linter in pyflakes: https://github.com/PyCQA/pyflakes/pull/72

Pyflakes only emits an error if the values are different for the duplicate keys. This lint copies most of the logic but does the opposite - when we have multiple identical keys with the identical values, we emit an error on all but the first entry.

As with Pyflakes, it only works when the keys are tuples, literals, or variable names.

This could have been _much_ simpler if we could just emit an error on all duplicate keys regardless of their values, but the conversation in the PR for B033 indicated that we should avoid duplication with Pyflakes.

https://github.com/PyCQA/flake8-bugbear/pull/373