### PR TITLE
add except* support to B012&B025

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,6 +360,11 @@ Change Log
 ----------
 
 
+FUTURE
+~~~~~~
+
+* B012 and B025 now also handle try/except*
+
 24.10.31
 ~~~~~~~~
 

--- a/bugbear.py
+++ b/bugbear.py
@@ -457,7 +457,7 @@ class BugBearVisitor(ast.NodeVisitor):
         else:
             self.b040_caught_exception = B040CaughtException(node.name, False)
 
-        names = self.check_for_b013_b029_b030(node)
+        names = self.check_for_b013_b014_b029_b030(node)
 
         if (
             "BaseException" in names
@@ -603,6 +603,8 @@ class BugBearVisitor(ast.NodeVisitor):
         self.check_for_b012(node)
         self.check_for_b025(node)
         self.generic_visit(node)
+
+    visit_TryStar = visit_Try
 
     def visit_Compare(self, node) -> None:
         self.check_for_b015(node)
@@ -770,7 +772,7 @@ class BugBearVisitor(ast.NodeVisitor):
         for child in node.finalbody:
             _loop(child, (ast.Return, ast.Continue, ast.Break))
 
-    def check_for_b013_b029_b030(self, node: ast.ExceptHandler) -> list[str]:
+    def check_for_b013_b014_b029_b030(self, node: ast.ExceptHandler) -> list[str]:
         handlers: Iterable[ast.expr | None] = _flatten_excepthandler(node.type)
         names: list[str] = []
         bad_handlers: list[object] = []
@@ -2058,6 +2060,7 @@ class B020NameFinder(NameFinder):
 error = namedtuple("error", "lineno col message type vars")
 Error = partial(partial, error, type=BugBearChecker, vars=())
 
+# note: bare except* is a syntax error
 B001 = Error(
     message=(
         "B001 Do not use bare `except:`, it also catches unexpected "

--- a/tests/b012_py311.py
+++ b/tests/b012_py311.py
@@ -1,0 +1,29 @@
+def a():
+    try:
+        pass
+    except* Exception:
+        pass
+    finally:
+        return  # warning
+
+
+def b():
+    try:
+        pass
+    except* Exception:
+        pass
+    finally:
+        if 1 + 0 == 2 - 1:
+            return  # warning
+
+
+def c():
+    try:
+        pass
+    except* Exception:
+        pass
+    finally:
+        try:
+            return  # warning
+        except* Exception:
+            pass

--- a/tests/b013_py311.py
+++ b/tests/b013_py311.py
@@ -1,0 +1,40 @@
+"""
+Should emit:
+B013 - on lines 10 and 28
+"""
+
+import re
+
+try:
+    pass
+except* (ValueError,):
+    # pointless use of tuple
+    pass
+
+# fmt: off
+# Turn off black to keep brackets around
+# single except*ion for testing purposes.
+try:
+    pass
+except* (ValueError):
+    # not using a tuple means it's OK (if odd)
+    pass
+# fmt: on
+
+try:
+    pass
+except* ValueError:
+    # no warning here, all good
+    pass
+
+try:
+    pass
+except* (re.error,):
+    # pointless use of tuple with dotted attribute
+    pass
+
+try:
+    pass
+except* (a.b.c.d, b.c.d):
+    # attribute of attribute, etc.
+    pass

--- a/tests/b014_py311.py
+++ b/tests/b014_py311.py
@@ -1,0 +1,76 @@
+"""
+This is a copy of b014 but with except* instead. Should emit:
+B014 - on lines 11, 17, 28, 42, 49, 56, and 74.
+"""
+
+import binascii
+import re
+
+try:
+    pass
+except* (Exception, TypeError):
+    # TypeError is a subclass of Exception, so it doesn't add anything
+    pass
+
+try:
+    pass
+except* (OSError, OSError) as err:
+    # Duplicate exception types are useless
+    pass
+
+
+class MyError(Exception):
+    pass
+
+
+try:
+    pass
+except* (MyError, MyError):
+    # Detect duplicate non-builtin errors
+    pass
+
+
+try:
+    pass
+except* (MyError, Exception) as e:
+    # Don't assume that we're all subclasses of Exception
+    pass
+
+
+try:
+    pass
+except* (MyError, BaseException) as e:
+    # But we *can* assume that everything is a subclass of BaseException
+    raise e
+
+
+try:
+    pass
+except* (re.error, re.error):
+    # Duplicate exception types as attributes
+    pass
+
+
+try:
+    pass
+except* (IOError, EnvironmentError, OSError):
+    # Detect if a primary exception and any its aliases are present.
+    #
+    # Since Python 3.3, IOError, EnvironmentError, WindowsError, mmap.error,
+    # socket.error and select.error are aliases of OSError. See PEP 3151 for
+    # more info.
+    pass
+
+
+try:
+    pass
+except* (MyException, NotImplemented):
+    # NotImplemented is not an exception, let's not crash on it.
+    pass
+
+
+try:
+    pass
+except* (ValueError, binascii.Error):
+    # binascii.Error is a subclass of ValueError.
+    pass

--- a/tests/b025_py311.py
+++ b/tests/b025_py311.py
@@ -1,0 +1,38 @@
+"""
+Should emit:
+B025 - on lines 15, 22, 31
+"""
+
+import pickle
+
+try:
+    a = 1
+except* ValueError:
+    a = 2
+finally:
+    a = 3
+
+try:
+    a = 1
+except* ValueError:
+    a = 2
+except* ValueError:
+    a = 2
+
+try:
+    a = 1
+except* pickle.PickleError:
+    a = 2
+except* ValueError:
+    a = 2
+except* pickle.PickleError:
+    a = 2
+
+try:
+    a = 1
+except* (ValueError, TypeError):
+    a = 2
+except* ValueError:
+    a = 2
+except* (OSError, TypeError):
+    a = 2

--- a/tests/b029_py311.py
+++ b/tests/b029_py311.py
@@ -1,0 +1,14 @@
+"""
+Should emit:
+B029 - on lines 8 and 13
+"""
+
+try:
+    pass
+except* ():
+    pass
+
+try:
+    pass
+except* () as e:
+    pass

--- a/tests/b030_py311.py
+++ b/tests/b030_py311.py
@@ -1,0 +1,40 @@
+try:
+    pass
+except* (ValueError, (RuntimeError, (KeyError, TypeError))):  # error
+    pass
+
+try:
+    pass
+except* (ValueError, *(RuntimeError, *(KeyError, TypeError))):  # ok
+    pass
+
+try:
+    pass
+except* 1:  # error
+    pass
+
+try:
+    pass
+except* (1, ValueError):  # error
+    pass
+
+try:
+    pass
+except* (ValueError, *(RuntimeError, TypeError)):  # ok
+    pass
+
+
+def what_to_catch():
+    return (ValueError, TypeError)
+
+
+try:
+    pass
+except* what_to_catch():  # ok
+    pass
+
+
+try:
+    pass
+except* a.b[1].c:  # ok
+    pass

--- a/tests/b036_py311.py
+++ b/tests/b036_py311.py
@@ -1,0 +1,59 @@
+
+try:
+    pass
+except* BaseException:  # bad
+    print("aaa")
+    pass
+
+
+try:
+    pass
+except* BaseException as ex:  # bad
+    print(ex)
+    pass
+
+
+try:
+    pass
+except* ValueError:
+    raise
+except* BaseException:  # bad
+    pass
+
+
+try:
+    pass
+except* BaseException:  # ok - reraised
+    print("aaa")
+    raise
+
+
+try:
+    pass
+except* BaseException as ex:  # bad - raised something else
+    print("aaa")
+    raise KeyError from ex
+
+try:
+    pass
+except* BaseException as e:
+    raise e  # ok - raising same thing
+
+try:
+    pass
+except* BaseException:
+    if 0:
+        raise  # ok - raised somewhere within branch
+
+try:
+    pass
+except* BaseException:
+    try:  # nested try
+        pass
+    except* ValueError:
+        raise  # bad - raising within a nested try/except*, but not in the main one
+
+try:
+    pass
+except* BaseException:
+    raise a.b from None  # bad (regression test for #449)

--- a/tests/b904_py311.py
+++ b/tests/b904_py311.py
@@ -1,0 +1,55 @@
+"""
+Should emit:
+B904 - on lines 10, 11 and 16
+"""
+
+try:
+    raise ValueError
+except* ValueError:
+    if "abc":
+        raise TypeError
+    raise UserWarning
+except* AssertionError:
+    raise  # Bare `raise` should not be an error
+except* Exception as err:
+    assert err
+    raise Exception("No cause here...")
+except* BaseException as base_err:
+    # Might use this instead of bare raise with the `.with_traceback()` method
+    raise base_err
+finally:
+    raise Exception("Nothing to chain from, so no warning here")
+
+try:
+    raise ValueError
+except* ValueError:
+    # should not emit, since we are not raising something
+    def proxy():
+        raise NameError
+
+
+try:
+    from preferred_library import Thing
+except* ImportError:
+    try:
+        from fallback_library import Thing
+    except* ImportError:
+
+        class Thing:
+            def __getattr__(self, name):
+                # same as the case above, should not emit.
+                raise AttributeError
+
+
+try:
+    from preferred_library import Thing
+except* ImportError:
+    try:
+        from fallback_library import Thing
+    except* ImportError:
+
+        def context_switch():
+            try:
+                raise ValueError
+            except* ValueError:
+                raise Exception

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -207,16 +207,16 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         all_errors = [
-            B012(5, 8),
-            B012(13, 12),
-            B012(21, 12),
-            B012(31, 12),
-            B012(44, 20),
-            B012(66, 12),
-            B012(78, 12),
-            B012(94, 12),
-            B012(101, 8),
-            B012(107, 8),
+            B012(5, 8, vars=("",)),
+            B012(13, 12, vars=("",)),
+            B012(21, 12, vars=("",)),
+            B012(31, 12, vars=("",)),
+            B012(44, 20, vars=("",)),
+            B012(66, 12, vars=("",)),
+            B012(78, 12, vars=("",)),
+            B012(94, 12, vars=("",)),
+            B012(101, 8, vars=("",)),
+            B012(107, 8, vars=("",)),
         ]
         self.assertEqual(errors, self.errors(*all_errors))
 
@@ -226,9 +226,9 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         all_errors = [
-            B012(7, 8),
-            B012(17, 12),
-            B012(27, 12),
+            B012(7, 8, vars=("*",)),
+            B012(17, 12, vars=("*",)),
+            B012(27, 12, vars=("*",)),
         ]
         self.assertEqual(errors, self.errors(*all_errors))
 
@@ -237,7 +237,19 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B013(10, 0, vars=("ValueError",)), B013(32, 0, vars=("re.error",))
+            B013(10, 0, vars=("ValueError", "")),
+            B013(32, 0, vars=("re.error", "")),
+        )
+        self.assertEqual(errors, expected)
+
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b013_py311(self):
+        filename = Path(__file__).absolute().parent / "b013_py311.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B013(10, 0, vars=("ValueError", "*")),
+            B013(32, 0, vars=("re.error", "*")),
         )
         self.assertEqual(errors, expected)
 
@@ -246,17 +258,17 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B014(11, 0, vars=("Exception, TypeError", "", "Exception")),
-            B014(17, 0, vars=("OSError, OSError", " as err", "OSError")),
-            B014(28, 0, vars=("MyError, MyError", "", "MyError")),
-            B014(42, 0, vars=("MyError, BaseException", " as e", "BaseException")),
-            B014(49, 0, vars=("re.error, re.error", "", "re.error")),
+            B014(11, 0, vars=("Exception, TypeError", "", "Exception", "")),
+            B014(17, 0, vars=("OSError, OSError", " as err", "OSError", "")),
+            B014(28, 0, vars=("MyError, MyError", "", "MyError", "")),
+            B014(42, 0, vars=("MyError, BaseException", " as e", "BaseException", "")),
+            B014(49, 0, vars=("re.error, re.error", "", "re.error", "")),
             B014(
                 56,
                 0,
-                vars=("IOError, EnvironmentError, OSError", "", "OSError"),
+                vars=("IOError, EnvironmentError, OSError", "", "OSError", ""),
             ),
-            B014(74, 0, vars=("ValueError, binascii.Error", "", "ValueError")),
+            B014(74, 0, vars=("ValueError, binascii.Error", "", "ValueError", "")),
         )
         self.assertEqual(errors, expected)
 
@@ -266,17 +278,17 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B014(11, 0, vars=("Exception, TypeError", "", "Exception")),
-            B014(17, 0, vars=("OSError, OSError", " as err", "OSError")),
-            B014(28, 0, vars=("MyError, MyError", "", "MyError")),
-            B014(42, 0, vars=("MyError, BaseException", " as e", "BaseException")),
-            B014(49, 0, vars=("re.error, re.error", "", "re.error")),
+            B014(11, 0, vars=("Exception, TypeError", "", "Exception", "*")),
+            B014(17, 0, vars=("OSError, OSError", " as err", "OSError", "*")),
+            B014(28, 0, vars=("MyError, MyError", "", "MyError", "*")),
+            B014(42, 0, vars=("MyError, BaseException", " as e", "BaseException", "*")),
+            B014(49, 0, vars=("re.error, re.error", "", "re.error", "*")),
             B014(
                 56,
                 0,
-                vars=("IOError, EnvironmentError, OSError", "", "OSError"),
+                vars=("IOError, EnvironmentError, OSError", "", "OSError", "*"),
             ),
-            B014(74, 0, vars=("ValueError, binascii.Error", "", "ValueError")),
+            B014(74, 0, vars=("ValueError, binascii.Error", "", "ValueError", "*")),
         )
         self.assertEqual(errors, expected)
 
@@ -571,8 +583,8 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B029(8, 0),
-            B029(13, 0),
+            B029(8, 0, vars=("",)),
+            B029(13, 0, vars=("",)),
         )
         self.assertEqual(errors, expected)
 
@@ -582,8 +594,8 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
-            B029(8, 0),
-            B029(13, 0),
+            B029(8, 0, vars=("*",)),
+            B029(13, 0, vars=("*",)),
         )
         self.assertEqual(errors, expected)
 
@@ -987,10 +999,10 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = [
-            B904(10, 8),
-            B904(11, 4),
-            B904(16, 4),
-            B904(55, 16),
+            B904(10, 8, vars=("",)),
+            B904(11, 4, vars=("",)),
+            B904(16, 4, vars=("",)),
+            B904(55, 16, vars=("",)),
         ]
         self.assertEqual(errors, self.errors(*expected))
 
@@ -1000,10 +1012,10 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = [
-            B904(10, 8),
-            B904(11, 4),
-            B904(16, 4),
-            B904(55, 16),
+            B904(10, 8, vars=("*",)),
+            B904(11, 4, vars=("*",)),
+            B904(16, 4, vars=("*",)),
+            B904(55, 16, vars=("*",)),
         ]
         self.assertEqual(errors, self.errors(*expected))
 

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -220,6 +220,18 @@ class BugbearTestCase(unittest.TestCase):
         ]
         self.assertEqual(errors, self.errors(*all_errors))
 
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b012_py311(self):
+        filename = Path(__file__).absolute().parent / "b012_py311.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        all_errors = [
+            B012(7, 8),
+            B012(17, 12),
+            B012(27, 12),
+        ]
+        self.assertEqual(errors, self.errors(*all_errors))
+
     def test_b013(self):
         filename = Path(__file__).absolute().parent / "b013.py"
         bbc = BugBearChecker(filename=str(filename))
@@ -231,6 +243,26 @@ class BugbearTestCase(unittest.TestCase):
 
     def test_b014(self):
         filename = Path(__file__).absolute().parent / "b014.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B014(11, 0, vars=("Exception, TypeError", "", "Exception")),
+            B014(17, 0, vars=("OSError, OSError", " as err", "OSError")),
+            B014(28, 0, vars=("MyError, MyError", "", "MyError")),
+            B014(42, 0, vars=("MyError, BaseException", " as e", "BaseException")),
+            B014(49, 0, vars=("re.error, re.error", "", "re.error")),
+            B014(
+                56,
+                0,
+                vars=("IOError, EnvironmentError, OSError", "", "OSError"),
+            ),
+            B014(74, 0, vars=("ValueError, binascii.Error", "", "ValueError")),
+        )
+        self.assertEqual(errors, expected)
+
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b014_py311(self):
+        filename = Path(__file__).absolute().parent / "b014_py311.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
@@ -481,6 +513,21 @@ class BugbearTestCase(unittest.TestCase):
             ),
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b025_py311(self):
+        filename = Path(__file__).absolute().parent / "b025_py311.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        self.assertEqual(
+            errors,
+            self.errors(
+                B025(15, 0, vars=("ValueError",)),
+                B025(22, 0, vars=("pickle.PickleError",)),
+                B025(31, 0, vars=("TypeError",)),
+                B025(31, 0, vars=("ValueError",)),
+            ),
+        )
+
     def test_b026(self):
         filename = Path(__file__).absolute().parent / "b026.py"
         bbc = BugBearChecker(filename=str(filename))
@@ -529,8 +576,31 @@ class BugbearTestCase(unittest.TestCase):
         )
         self.assertEqual(errors, expected)
 
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b029_py311(self):
+        filename = Path(__file__).absolute().parent / "b029_py311.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B029(8, 0),
+            B029(13, 0),
+        )
+        self.assertEqual(errors, expected)
+
     def test_b030(self):
         filename = Path(__file__).absolute().parent / "b030.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B030(3, 0),
+            B030(13, 0),
+            B030(18, 0),
+        )
+        self.assertEqual(errors, expected)
+
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b030_py311(self):
+        filename = Path(__file__).absolute().parent / "b030_py311.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
@@ -616,6 +686,21 @@ class BugbearTestCase(unittest.TestCase):
 
     def test_b036(self) -> None:
         filename = Path(__file__).absolute().parent / "b036.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = self.errors(
+            B036(4, 0),
+            B036(11, 0),
+            B036(20, 0),
+            B036(33, 0),
+            B036(50, 0),
+            B036(58, 0),
+        )
+        self.assertEqual(errors, expected)
+
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b036_py311(self) -> None:
+        filename = Path(__file__).absolute().parent / "b036_py311.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = self.errors(
@@ -899,6 +984,19 @@ class BugbearTestCase(unittest.TestCase):
 
     def test_b904(self):
         filename = Path(__file__).absolute().parent / "b904.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = [
+            B904(10, 8),
+            B904(11, 4),
+            B904(16, 4),
+            B904(55, 16),
+        ]
+        self.assertEqual(errors, self.errors(*expected))
+
+    @unittest.skipIf(sys.version_info < (3, 11), "requires 3.11+")
+    def test_b904_py311(self):
+        filename = Path(__file__).absolute().parent / "b904_py311.py"
         bbc = BugBearChecker(filename=str(filename))
         errors = list(bbc.run())
         expected = [


### PR DESCRIPTION
This PR creates a `visit_TryStar` that mostly just calls `visit_Try`, enabling B012 & B025 to work with `try/except*`

Because `ExceptHandler` is also used for `TryStar`, we already have support for free for B014, B029, B030, B036 and B904.
I opted to add tests for them anyway, but it did end up with a somewhat silly amount of added tests - most of which are just pure copy-paste's of their original test files. Another option is writing a single `except_star.py` file that tests all of them, or writing a transformer test that goes through the original files, does a search+replace for `except`->`except*`, and then tests them on the fly. Though the latter option would also involve some rejigging to get the expected errors shared from the original `test_bxxx` functions.
Another case for #419 

B001 is the only except-related rule I found that's not revelant, since `except*:` is a syntax error.

EDIT: error message updates added in https://github.com/PyCQA/flake8-bugbear/pull/500/commits/adca610ce7d1d50c856586d6cb8465fe37dff10b
~~I have *not* updated error messages. For B012 (unclear if necessary) and B025 it'd be fairly straightforward, could make `visit_TryStar` pass a parameter to `check_for_b012`/`check_for_b025`. For the others it'd have to involve a property `BugBearVisitor.in_trystar`... I guess I should just do that, even if somewhat tedious.~~