### PR TITLE
Add B911: itertools.batched without strict=

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,10 @@ This is meant to be enabled by developers writing visitors using the ``ast`` mod
 
 **B910**: Use Counter() instead of defaultdict(int) to avoid excessive memory use as the default dict will record missing keys with the default value when accessed.
 
+**B911**: ``itertools.batched()`` without an explicit `strict=` parameter set. ``strict=True`` causes the resulting iterator to raise a ``ValueError`` if the final batch is shorter than ``n``.
+
+The ``strict=`` argument was added in Python 3.13, so don't enable this flag for code that should work on <3.13.
+
 **B950**: Line too long. This is a pragmatic equivalent of
 ``pycodestyle``'s ``E501``: it considers "max-line-length" but only triggers
 when the value has been exceeded by **more than 10%**. ``noqa`` and ``type: ignore`` comments are ignored. You will no

--- a/tests/b911_py313.py
+++ b/tests/b911_py313.py
@@ -1,0 +1,24 @@
+import itertools
+from itertools import batched
+
+# Expect B911
+batched(range(3), 2)
+batched(range(3), n=2)
+batched(iterable=range(3), n=2)
+itertools.batched(range(3), 2)
+itertools.batched(range(3), n=2)
+itertools.batched(iterable=range(3), n=2)
+
+# OK
+batched(range(3), 2, strict=True)
+batched(range(3), n=2, strict=True)
+batched(iterable=range(3), n=2, strict=True)
+batched(range(3), 2, strict=False)
+batched(range(3), n=2, strict=False)
+batched(iterable=range(3), n=2, strict=False)
+itertools.batched(range(3), 2, strict=True)
+itertools.batched(range(3), n=2, strict=True)
+itertools.batched(iterable=range(3), n=2, strict=True)
+itertools.batched(range(3), 2, strict=False)
+itertools.batched(range(3), n=2, strict=False)
+itertools.batched(iterable=range(3), n=2, strict=False)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -59,6 +59,7 @@ from bugbear import (
     B908,
     B909,
     B910,
+    B911,
     B950,
     BugBearChecker,
     BugBearVisitor,
@@ -1071,6 +1072,21 @@ class BugbearTestCase(unittest.TestCase):
         expected = [
             B910(3, 4),
             B910(8, 4),
+        ]
+        self.assertEqual(errors, self.errors(*expected))
+
+    @unittest.skipIf(sys.version_info < (3, 13), "requires 3.13+")
+    def test_b911(self):
+        filename = Path(__file__).absolute().parent / "b911_py313.py"
+        bbc = BugBearChecker(filename=str(filename))
+        errors = list(bbc.run())
+        expected = [
+            B911(5, 0),
+            B911(6, 0),
+            B911(7, 0),
+            B911(8, 0),
+            B911(9, 0),
+            B911(10, 0),
         ]
         self.assertEqual(errors, self.errors(*expected))
 


### PR DESCRIPTION
Checks calls to `itertools.batched` and `batch` similar to the implementation of B031.

Closes #498