### PR TITLE
Move project to >= 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
         os: [ubuntu-latest]
 

--- a/README.rst
+++ b/README.rst
@@ -475,7 +475,7 @@ Change Log
 UNRELEASED
 ~~~~~~~~~~
 
-* flake8-bugbear is now >= 3.9 project like flake8>=7.2.0
+* flake8-bugbear now requires at least Python 3.9, like flake8>=7.2.0
 * B028: Skip if skip_file_prefixes is used (#503)
 
 24.12.12

--- a/README.rst
+++ b/README.rst
@@ -475,6 +475,7 @@ Change Log
 UNRELEASED
 ~~~~~~~~~~
 
+* flake8-bugbear is now >= 3.9 project like flake8>=7.2.0
 * B028: Skip if skip_file_prefixes is used (#503)
 
 24.12.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -36,8 +35,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = ">=3.8.1"
-dependencies = ["flake8>=6.0.0", "attrs>=22.2.0"]
+requires-python = ">=3.9"
+dependencies = ["flake8>=7.2.0", "attrs>=22.2.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
- CI failed as we'd hoped and it's time to move to >= 3.9 cpython to match flake8
- Here we update all configuration and metadata etc. etc.

This fixes "flake8_py_version_check" CI failing like: https://github.com/PyCQA/flake8-bugbear/actions/runs/14150950748/job/39644039034