### PR TITLE
drop 3.8, unpin mypy dep in tox, fix typing errors, add some type hints

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -482,7 +482,7 @@ class BugBearVisitor(ast.NodeVisitor):
     def visit_UAdd(self, node: ast.UAdd) -> None:
         trailing_nodes = list(map(type, self.node_window[-4:]))
         if trailing_nodes == [ast.UnaryOp, ast.UAdd, ast.UnaryOp, ast.UAdd]:
-            originator = cast("ast.UnaryOp", self.node_window[-4])
+            originator = cast(ast.UnaryOp, self.node_window[-4])
             self.errors.append(B002(originator.lineno, originator.col_offset))
         self.generic_visit(node)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 # The test environment and commands
 [tox]
 # default environments to run without `-e`
-envlist = py38, py39, py310, py311, py312, py313, pep8_naming, mypy
+envlist = py39, py310, py311, py312, py313, pep8_naming, mypy
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311,pep8_naming
-    3.12: py312,mypy
-    3.13-dev: py313
+    3.12: py312
+    3.13: py313,mypy
+    # blocked by https://github.com/PyO3/pyo3/issues/5107
+    # 3.14: py314
 
 [testenv]
 description = Run coverage
@@ -32,8 +33,8 @@ commands =
     coverage run tests/test_bugbear.py -k b902 {posargs}
     coverage report -m
 
-[testenv:mypy]
+[testenv:{py39-,py310-,py311-,py312-,py313-}mypy]
 deps =
-    mypy==1.10.1
+    mypy
 commands =
     mypy bugbear.py


### PR DESCRIPTION
the `partial` approach didn't pass typing anymore, though I didn't dig terribly deep into why that might be the case, I simply replaced it with a factory class.

testing 3.14 is blocked by hypothesmith->libcst->PyO3 https://github.com/PyO3/pyo3/issues/5107