### PR TITLE
#525 disable B042

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # Keep in sync with .flake8. This copy here is needed for source packages
 # to be able to pass tests without failing selfclean check.
-ignore = E203, E302, E501, E999, W503
+ignore = E203, E302, E501, E999, W503, B042
 max-line-length = 88
 max-complexity = 12
 select = B,C,E,F,W,B9


### PR DESCRIPTION
As discussed in #525 until better documentation and fix for false positives are solved for B042, it will be disabled.

Sorry if this is not the correct way of disabling things in Flake8, I have no experience in flake8 development.