### PR TITLE
Emit B028 when `skip_file_prefixes` is an empty tuple

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1745,7 +1745,11 @@ class BugBearVisitor(ast.NodeVisitor):
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id == "warnings"
             and not any(kw.arg == "stacklevel" for kw in node.keywords)
-            and not any(kw.arg == "skip_file_prefixes" for kw in node.keywords)
+            and not any(
+                kw.arg == "skip_file_prefixes"
+                and not (isinstance(kw.value, ast.Tuple) and not kw.value.elts)
+                for kw in node.keywords
+            )
             and len(node.args) < 3
             and not any(isinstance(a, ast.Starred) for a in node.args)
             and not any(kw.arg is None for kw in node.keywords)

--- a/tests/eval_files/b028.py
+++ b/tests/eval_files/b028.py
@@ -17,3 +17,5 @@ kwargs = {"message": "test", "category": DeprecationWarning, "stacklevel": 1}
 warnings.warn(**kwargs)
 warnings.warn(*args, **kwargs)
 warnings.warn("test", DeprecationWarning, skip_file_prefixes=["foo"])
+warnings.warn("test", DeprecationWarning, skip_file_prefixes=("/path",))
+warnings.warn("test", DeprecationWarning, skip_file_prefixes=())  # B028: 0


### PR DESCRIPTION
## Summary
- `warnings.warn("test", skip_file_prefixes=())` now triggers B028, since an empty tuple is equivalent to not passing `skip_file_prefixes` at all
- Non-empty `skip_file_prefixes` still correctly suppresses B028

Closes #510

## Test plan
- Added test case for `skip_file_prefixes=()` (should trigger B028)
- Added test case for `skip_file_prefixes=("/path",)` (should NOT trigger B028)
- All existing tests continue to pass