### PR TITLE
fix(b912): only emit on Python 3.14+ where `map()` supports `strict=` (#548)

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -1622,6 +1622,10 @@ class BugBearVisitor(ast.NodeVisitor):
             self.add_error("B905", node)
 
     def check_for_b912(self, node: ast.Call) -> None:
+        # `map(strict=...)` was added in Python 3.14; emitting on older
+        # interpreters would flag valid code.
+        if sys.version_info < (3, 14):
+            return
         if not (
             isinstance(node.func, ast.Name)
             and node.func.id == "map"

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -201,6 +201,30 @@ class BugbearTestCase(unittest.TestCase):
             ),
         )
 
+    def test_b912_suppressed_on_pre_3_14(self):
+        # `map(strict=...)` only exists on Python 3.14+, so the check should
+        # be a noop on older interpreters.
+        from unittest.mock import patch
+
+        import bugbear
+
+        filename = EVAL_FILES_DIR / "b912_py314.py"
+        with patch.object(bugbear.sys, "version_info", (3, 13, 0, "final", 0)):
+            bbc = BugBearChecker(filename=str(filename))
+            errors = [e for e in bbc.run() if e[2].startswith("B912")]
+        self.assertEqual(errors, [])
+
+    def test_b912_emitted_on_3_14(self):
+        from unittest.mock import patch
+
+        import bugbear
+
+        filename = EVAL_FILES_DIR / "b912_py314.py"
+        with patch.object(bugbear.sys, "version_info", (3, 14, 0, "final", 0)):
+            bbc = BugBearChecker(filename=str(filename))
+            errors = [e for e in bbc.run() if e[2].startswith("B912")]
+        self.assertEqual(len(errors), 2)
+
     def test_b9_flake8_next_default_options(self):
         filename = EVAL_FILES_DIR / "b950.py"
 


### PR DESCRIPTION
Closes #548. You said "I would take a PR to add this check and let checks use it to guage to be a noop or not." Gates `check_for_b912` on `sys.version_info >= (3, 14)` so the rule no-ops on older interpreters where `map(strict=...)` would be a TypeError.