### PR TITLE
B031: don't count store-context references as generator uses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -499,6 +499,7 @@ UNRELEASED
 ~~~~~~~~~~
 
 * B018: handle also useless calls such as `isinstance(x, int)` without assigning or using the result
+* B031: don't count a store-context reference (e.g. an annotation target like `group: T`) as a use of the `groupby` generator (#465)
 
 25.11.29
 ~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -1215,11 +1215,18 @@ class BugBearVisitor(ast.NodeVisitor):
                             if (
                                 isinstance(nested_node, ast.Name)
                                 and nested_node.id == group_name
+                                and isinstance(nested_node.ctx, ast.Load)
                             ):
                                 self.add_error("B031", nested_node, nested_node.id)
 
-                    # Handle multiple uses
-                    if isinstance(node, ast.Name) and node.id == group_name:
+                    # Handle multiple uses. Count only loads: a store-context
+                    # reference, such as an annotation target (`group: T`), is
+                    # not a read of the generator (#465).
+                    if (
+                        isinstance(node, ast.Name)
+                        and node.id == group_name
+                        and isinstance(node.ctx, ast.Load)
+                    ):
                         num_usages += 1
                         if num_usages > 1:
                             self.add_error("B031", node, node.id)

--- a/tests/eval_files/b031.py
+++ b/tests/eval_files/b031.py
@@ -63,3 +63,9 @@ for (_key1, _key2), (_value1, _value2) in groupby(
 ):
     collect_shop_items("Jane", group[1])
     collect_shop_items("Joe", group[1])
+
+
+# Annotating the loop variable is not a second usage of the generator (#465)
+for _section, section_items in groupby(items, key=lambda p: p[1]):
+    section_items: list
+    collect_shop_items("Jane", section_items)


### PR DESCRIPTION
## what

fixes a B031 false positive: type-annotating (or assigning to) the `groupby` loop variable was counted as a "use", so a single real use plus an annotation tripped "used more than once".

```python
for _, group in groupby(items):
    group: SomeType        # annotation, not a use
    do_something(group)    # the only real use
```

before: B031 fires. after: clean.

## why

the B031 usage-counter walked the loop body and counted every `Name` matching the group variable regardless of context. an annotation target (`group: T`) or an assignment target is a `Store`-context `Name`, not a use of the generator, so it inflated the count. count only `Load`-context references.

## scope

this is the type-annotation / store-context case raised in the comments on #465. the original if/else case is handled separately by #557, and the two are orthogonal: if/else uses are both loads, untouched by this change, so they don't collide. real double-uses still fire B031.

## tests

a case in `tests/eval_files/b031.py` that annotates the loop variable then uses it once, expecting no B031. it fails before the fix and passes after. full suite stays green.

Addresses #465.
