### PR TITLE
B902: don't false-positive on metaclasses with a dotted base

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,8 @@ to bugs.  Use native ``async def`` coroutines or mark intentional
 **B902**: Invalid first argument used for method. Use ``self`` for
 instance methods, and ``cls`` for class methods (which includes ``__new__``
 and ``__init_subclass__``) or instance methods of metaclasses (detected as
-classes directly inheriting from ``type``).
+classes inheriting from ``type``, ``ABCMeta`` or ``EnumMeta``, written
+either bare or dotted such as ``abc.ABCMeta``).
 
 .. _B903:
 
@@ -500,6 +501,7 @@ UNRELEASED
 
 * B018: handle also useless calls such as `isinstance(x, int)` without assigning or using the result
 * B031: don't count a store-context reference (e.g. an annotation target like `group: T`) as a use of the `groupby` generator (#465)
+* B902: don't raise a false positive on a metaclass defined with a dotted base such as `abc.ABCMeta` or `enum.EnumMeta` (#411)
 
 25.11.29
 ~~~~~~~~

--- a/bugbear.py
+++ b/bugbear.py
@@ -1411,7 +1411,11 @@ class BugBearVisitor(ast.NodeVisitor):
             # `cls`?
             return
 
-        bases = {b.id for b in cls.bases if isinstance(b, ast.Name)}
+        bases = {
+            b.id if isinstance(b, ast.Name) else b.attr
+            for b in cls.bases
+            if isinstance(b, (ast.Name, ast.Attribute))
+        }
         if any(basetype in bases for basetype in ("type", "ABCMeta", "EnumMeta")):
             if is_classmethod(decorators):
                 expected_first_args = B902_METACLS

--- a/tests/eval_files/b024.py
+++ b/tests/eval_files/b024.py
@@ -82,7 +82,7 @@ class notabc_Base_1(notabc.ABC):  # safe
 
 
 class multi_super_1(notabc.ABC, abc.ABCMeta):  # safe
-    def method(self):
+    def method(cls):
         foo()
 
 
@@ -97,7 +97,7 @@ class non_keyword_abcmeta_1(ABCMeta):  # safe
 
 
 class non_keyword_abcmeta_2(abc.ABCMeta):  # safe
-    def method(self):
+    def method(cls):
         foo()
 
 

--- a/tests/eval_files/b902.py
+++ b/tests/eval_files/b902.py
@@ -77,3 +77,25 @@ class ImplicitClassMethods:
     def __init_subclass__(cls, *args, **kwargs): ...
 
     def __class_getitem__(cls, key): ...
+
+
+# A metaclass written with a dotted base (abc.ABCMeta / enum.EnumMeta) is
+# still a metaclass, so cls/metacls/mcs first args are fine here.
+class DottedABCMeta(abc.ABCMeta):
+    def __init__(cls, name, bases, d): ...
+
+    @classmethod
+    def __prepare__(metacls, name, bases):
+        return {}
+
+    def __new__(mcs, name, bases, namespace): ...
+
+
+class DottedEnumMeta(enum.EnumMeta):
+    def __new__(mcs, name, bases, namespace): ...
+
+
+# Detection stays precise: a wrong first arg on a dotted metaclass is still
+# reported, as a metaclass instance method expecting cls.
+class DottedMetaWarnings(abc.ABCMeta):
+    def __init__(self, name, bases, d): ... # B902: 17, "'self'", "metaclass instance", "cls"


### PR DESCRIPTION
## what

B902 raises a false positive on a metaclass whose base is written with a dotted name, e.g.

```python
import abc

class CustomMeta(abc.ABCMeta):
    def __new__(mcs, name, bases, ns): ...  # flagged, but mcs is correct here
```

This is issue #411.

## why

The B902 metaclass check builds the set of base names from bare `ast.Name` nodes only:

```python
bases = {b.id for b in cls.bases if isinstance(b, ast.Name)}
```

A dotted base like `abc.ABCMeta` is an `ast.Attribute`, so it gets dropped. The class is then treated as a plain class and its `cls`/`metacls`/`mcs` first arguments are flagged. #415 added detection for the bare `type`/`ABCMeta`/`EnumMeta` names back in 2023; the dotted form was the remaining gap, and #411 is still open.

## fix

Also take the attribute name from dotted `ast.Attribute` bases:

```python
bases = {
    b.id if isinstance(b, ast.Name) else b.attr
    for b in cls.bases
    if isinstance(b, (ast.Name, ast.Attribute))
}
```

Scoped to direct bases (transitive base chains stay out of scope). This is the same name-based heuristic the check already used, so dotted bases now behave like the bare ones.

## tests

`tests/eval_files/b902.py` gains dotted `abc.ABCMeta` and `enum.EnumMeta` metaclasses (clean), plus a precision case where a wrong first arg on a dotted metaclass is still reported as a metaclass instance method. Before the fix those clean fixtures emit spurious B902s and the precision error is lost; after, they are correct.

Two classes in `tests/eval_files/b024.py` (`multi_super_1`, `non_keyword_abcmeta_2`) directly subclass `abc.ABCMeta` and used `self`, which was only valid while the bug hid their metaclass-ness. They now use `cls`, consistent with the bare `non_keyword_abcmeta_1` sibling in the same file.

Also updated the B902 README entry, which only mentioned `type`, to cover `ABCMeta`/`EnumMeta` and dotted bases. Full suite green.

Fixes #411.
