### PR TITLE
Wrap visitor recursion errors in PluginExecutionFailed

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -26,6 +26,7 @@ from typing import (
 
 import attr  # type: ignore
 import pycodestyle  # type: ignore
+from flake8.exceptions import PluginExecutionFailed
 
 __version__ = "25.11.29"
 
@@ -106,7 +107,10 @@ class BugBearChecker:
             b008_b039_extend_immutable_calls=b008_b039_extend_immutable_calls,
             b902_classmethod_decorators=b902_classmethod_decorators,
         )
-        visitor.visit(self.tree)
+        try:
+            visitor.visit(self.tree)
+        except RecursionError as e:
+            raise PluginExecutionFailed(self.filename, self.name, e) from e
         for e in itertools.chain(visitor.errors, self.gen_line_based_checks()):
             if self.should_warn(e.message[:4]):
                 yield self.adapt_error(e)

--- a/bugbear.py
+++ b/bugbear.py
@@ -109,7 +109,7 @@ class BugBearChecker:
         )
         try:
             visitor.visit(self.tree)
-        except RecursionError as e:
+        except RuntimeError as e:
             raise PluginExecutionFailed(self.filename, self.name, e) from e
         for e in itertools.chain(visitor.errors, self.gen_line_based_checks()):
             if self.should_warn(e.message[:4]):

--- a/bugbear.py
+++ b/bugbear.py
@@ -109,8 +109,8 @@ class BugBearChecker:
         )
         try:
             visitor.visit(self.tree)
-        except RuntimeError as e:
-            raise PluginExecutionFailed(self.filename, self.name, e) from e
+        except RecursionError as exc:
+            raise PluginExecutionFailed(self.filename, self.name, exc) from exc
         for e in itertools.chain(visitor.errors, self.gen_line_based_checks()):
             if self.should_warn(e.message[:4]):
                 yield self.adapt_error(e)

--- a/tests/test_bugbear.py
+++ b/tests/test_bugbear.py
@@ -13,6 +13,7 @@ from argparse import Namespace
 from pathlib import Path
 
 import pytest
+from flake8.exceptions import PluginExecutionFailed
 
 from bugbear import (
     BugBearChecker,
@@ -234,6 +235,18 @@ class BugbearTestCase(unittest.TestCase):
         bbc = BugBearChecker(filename=str(filename), options=mock_options)
         errors = list(bbc.run())
         self.assertEqual(errors, [])
+
+    def test_recursion_error_is_wrapped(self):
+        from unittest.mock import patch
+
+        bbc = BugBearChecker(filename=str(EVAL_FILES_DIR / "b001.py"))
+        with patch.object(BugBearVisitor, "visit", side_effect=RecursionError("boom")):
+            with self.assertRaises(PluginExecutionFailed) as excinfo:
+                list(bbc.run())
+
+        self.assertEqual(excinfo.exception.filename, str(EVAL_FILES_DIR / "b001.py"))
+        self.assertEqual(excinfo.exception.plugin_name, "flake8-bugbear")
+        self.assertIsInstance(excinfo.exception.original_exception, RecursionError)
 
     def test_selfclean_bugbear(self):
         filename = Path(__file__).absolute().parent.parent / "bugbear.py"


### PR DESCRIPTION
Refs. https://github.com/PyCQA/flake8-bugbear/issues/295#issuecomment-4741745456

New UX:

```
$ uvx --with git+https://github.com/m-aciek/flake8-bugbear.git@copilot%2Fwrap-recursionerror-in-flake8-exception flake8
sympy/polys/numberfields/resolvent_lookup.py: "flake8-bugbear" failed during execution due to RecursionError('maximum recursion depth exceeded')
Run flake8 with greater verbosity to see more details
```

Previous UX:
```
$ uvx --with flake8-bugbear flake8
[… long stacktrace]
    return visitor(node)                                                                                                                                                                                         
  File "~/.local/share/uv/python/cpython-3.14.0-macos-x86_64-none/lib/python3.14/ast.py", line 516, in generic_visit                                                                            
    self.visit(value)                                                                                                                                                                                            
    ~~~~~~~~~~^^^^^^^                                                                                                                                                                                            
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/bugbear.py", line 455, in visit                                                                                    
    super().visit(node)                                                                                                                                                                                          
    ~~~~~~~~~~~~~^^^^^^                                                                                                                                                                                          
  File "~/.local/share/uv/python/cpython-3.14.0-macos-x86_64-none/lib/python3.14/ast.py", line 506, in visit                                                                                    
    return visitor(node)                                                                                                                                                                                         
  File "~/.local/share/uv/python/cpython-3.14.0-macos-x86_64-none/lib/python3.14/ast.py", line 516, in generic_visit                                                                            
    self.visit(value)                                                                                                                                                                                            
    ~~~~~~~~~~^^^^^^^                                                                                                                                                                                            
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/bugbear.py", line 455, in visit                                                                                    
    super().visit(node)                                                                                                                                                                                          
    ~~~~~~~~~~~~~^^^^^^                                                                                                                                                                                          
  File "~/.local/share/uv/python/cpython-3.14.0-macos-x86_64-none/lib/python3.14/ast.py", line 506, in visit                                                                                    
    return visitor(node)                                                                                                                                                                                         
  File "~/.local/share/uv/python/cpython-3.14.0-macos-x86_64-none/lib/python3.14/ast.py", line 510, in generic_visit                                                                            
    for field, value in iter_fields(node):                                                                                                                                                                       
                        ~~~~~~~~~~~^^^^^^                                                                                                                                                                        
RecursionError: maximum recursion depth exceeded                                                                                                                                                                 
"""                                                                                                                                                                                                              

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/bin/flake8", line 12, in <module>
    sys.exit(main())
             ~~~~^^
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
    ~~~~~~~^^^^^^
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
    ~~~~~~~~~^^^^^^
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/flake8/main/application.py", line 187, in _run
    self.run_checks()
    ~~~~~~~~~~~~~~~^^
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/flake8/main/application.py", line 103, in run_checks
    self.file_checker_manager.run()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/flake8/checker.py", line 235, in run
    self.run_parallel()
    ~~~~~~~~~~~~~~~~~^^
  File "~/.cache/uv/archive-v0/DcgALyZzrPwYWWKQ/lib/python3.14/site-packages/flake8/checker.py", line 204, in run_parallel
    self.results = list(pool.imap_unordered(_mp_run, self.filenames))
                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/uv/python/cpython-3.14.0-macos-x86_64-none/lib/python3.14/multiprocessing/pool.py", line 873, in next
    raise value
RecursionError: maximum recursion depth exceeded
```
