### PR TITLE
Fix B020 false positive for attribute iterables

### DIFF
--- a/bugbear.py
+++ b/bugbear.py
@@ -2214,6 +2214,18 @@ class FunctionDefDefaultsVisitor(ast.NodeVisitor):
 class B020NameFinder(NameFinder):
     """Ignore names defined within the local scope of a comprehension."""
 
+    def visit_Attribute(self, node) -> None:  # noqa: B906
+        pass
+
+    def visit_Call(self, node) -> None:
+        if isinstance(node.func, ast.Attribute):
+            self.visit(node.func.value)
+            self.visit(node.args)
+            self.visit(node.keywords)
+            return
+
+        self.generic_visit(node)
+
     def visit_GeneratorExp(self, node) -> None:
         self.visit(node.generators)
 

--- a/tests/eval_files/b020.py
+++ b/tests/eval_files/b020.py
@@ -38,3 +38,8 @@ for vars in [i for i in vars]:  # B020: 4, "vars"
 
 for var in sorted(range(10), key=lambda var: var.real):
     print(var)
+
+# Attribute access on the loop target name is not iterating over the same
+# object, so it should not trigger B020.
+for smoother in smoother.smoothers:
+    print(smoother)


### PR DESCRIPTION
Fixes #521.

## Summary
- stop B020 from treating the base name of a plain attribute iterable like `smoother.smoothers` as the iterable being reassigned
- keep method-call iterable cases such as `values.items()` covered
- add a regression case for attribute access on the loop target name

## Tests
- `uv run --python 3.13 --with '.[dev]' pytest tests/test_bugbear.py -k B020 -q`
- `uv run --python 3.13 --with '.[dev]' pytest tests/test_bugbear.py -q`
- `uv run --python 3.13 --with flake8 --with attrs flake8 bugbear.py tests/test_bugbear.py`
- `uv run --python 3.13 --with mypy --with types-flake8 --with attrs --with flake8 mypy bugbear.py`
- `git diff --check`