### PR TITLE
B028: flag empty skip_file_prefixes tuples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,8 @@ limitations make it difficult.
 **B028**: No explicit stacklevel argument found. The warn method from the warnings module uses a
 stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called.
 It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
-The check is skipped when skip_file_prefixes is used.
+The check is skipped when ``skip_file_prefixes`` is used, except for an explicitly empty tuple,
+which does not affect ``stacklevel``.
 
 .. _B029:
 
@@ -500,6 +501,8 @@ Change Log
 UNRELEASED
 ~~~~~~~~~~
 
+* B028: report ``warnings.warn`` calls that pass an explicitly empty
+  ``skip_file_prefixes`` tuple (#510)
 * B019: also flag `async_lru.alru_cache` and check cache decorators on `async def` methods (#488)
 * B023: don't flag a function whose every reference is a direct call inside the loop body:
   such a function cannot outlive the iteration it was defined in (#468, #380)

--- a/bugbear.py
+++ b/bugbear.py
@@ -2016,7 +2016,11 @@ class BugBearVisitor(ast.NodeVisitor):
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id == "warnings"
             and not any(kw.arg == "stacklevel" for kw in node.keywords)
-            and not any(kw.arg == "skip_file_prefixes" for kw in node.keywords)
+            and all(
+                kw.arg != "skip_file_prefixes"
+                or (isinstance(kw.value, ast.Tuple) and not kw.value.elts)
+                for kw in node.keywords
+            )
             and len(node.args) < 3
             and not any(isinstance(a, ast.Starred) for a in node.args)
             and not any(kw.arg is None for kw in node.keywords)

--- a/tests/eval_files/b028.py
+++ b/tests/eval_files/b028.py
@@ -2,7 +2,7 @@ import warnings
 
 """
 Should emit:
-B028 - on lines 8 and 9
+B028 - on lines 8, 9, and 20
 """
 
 warnings.warn("test", DeprecationWarning) # B028: 0
@@ -17,3 +17,6 @@ kwargs = {"message": "test", "category": DeprecationWarning, "stacklevel": 1}
 warnings.warn(**kwargs)
 warnings.warn(*args, **kwargs)
 warnings.warn("test", DeprecationWarning, skip_file_prefixes=["foo"])
+warnings.warn("test", DeprecationWarning, skip_file_prefixes=()) # B028: 0
+skip_file_prefixes = ()
+warnings.warn("test", DeprecationWarning, skip_file_prefixes=skip_file_prefixes)


### PR DESCRIPTION
Fixes #510

## Summary

- report B028 when `warnings.warn` receives an explicitly empty `skip_file_prefixes=()` tuple
- continue skipping calls whose prefixes are non-empty or cannot be determined statically
- document the exception and add regression coverage

An empty tuple does not cause `warnings.warn` to raise the effective stack level, so treating it like a populated `skip_file_prefixes` value suppresses a useful B028 diagnostic.

## Tests

- `.venv/bin/python -m pytest tests/test_bugbear.py -q` (81 passed)
- `.venv/bin/tox -e py314` (81 passed, 98% coverage)
- `.venv/bin/pre-commit run --all-files` (isort, black, flake8, rstcheck passed)

## Limitations

Dynamic expressions remain intentionally conservative: if the value of `skip_file_prefixes` is not a literal empty tuple, B028 is skipped as before.
